### PR TITLE
[Y26W2-127] security filter에서 swagger uri 허용 및 url 명시

### DIFF
--- a/src/main/java/com/yapp/backend/config/SecurityConfig.java
+++ b/src/main/java/com/yapp/backend/config/SecurityConfig.java
@@ -25,6 +25,11 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger/**"          // 만약 path: /swagger 로 설정했다면
+                        ).permitAll()
+                        .requestMatchers(
                                 "/oauth2/authorization/**",
                                 "/oauth/authorize",              // OAuth2 Authorization Endpoint
                                 "/login/oauth2/**"               // OAuth2 code Redirect URI

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,5 +10,7 @@ spring:
       - classpath:config/oauth/security.yml
 springdoc:
   swagger-ui:
-    with-credentials: true
     path: /swagger
+    config-url: /v3/api-docs/swagger-config
+    url: /v3/api-docs
+    disable-swagger-default-url: true


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/Y26W2-127` -> `main`

### 변경 사항
1. security filter 에서 swagger 관련 uri 접근 허용
2. swagger 접속 path와 url 명시

### PR 체크리스트
- [ ] 테스트 통과 여부
- [ ] merge branch 확인 여부

### 추가 전달 사항


### 테스트 결과

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * API 문서 및 Swagger UI 엔드포인트에 인증 없이 접근할 수 있도록 허용되었습니다.

* **설정 변경**
  * Swagger UI 설정이 개선되어 API 문서 경로와 구성이 명확하게 지정되고, 기본 Swagger URL이 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->