### PR TITLE
[Y26W2-132] 숙소 카드 리스트 조회 API 수정

### DIFF
--- a/src/main/java/com/yapp/backend/common/response/StandardResponse.java
+++ b/src/main/java/com/yapp/backend/common/response/StandardResponse.java
@@ -1,10 +1,14 @@
 package com.yapp.backend.common.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "API 응답의 표준 형식을 정의하는 클래스")
 public class StandardResponse<T> {
+    @Schema(description = "응답 유형", example = "SUCCESS")
     private ResponseType responseType; // "success" or "error"
+    @Schema(description = "응답 결과 데이터")
     private T result;
 
     public StandardResponse(ResponseType responseType, T result) {

--- a/src/main/java/com/yapp/backend/controller/AccommodationController.java
+++ b/src/main/java/com/yapp/backend/controller/AccommodationController.java
@@ -14,6 +14,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 숙소 도메인 Controller
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/accommodations")
@@ -21,14 +24,18 @@ public class AccommodationController implements AccommodationDocs {
 
 	private final AccommodationService accommodationService;
 
+	/**
+	 * 숙소 목록 조회 API
+	 */
 	@Override
 	@GetMapping("/search")
-	public ResponseEntity<StandardResponse<AccommodationPageResponse>> getAccommodationsByTitle(
+	public ResponseEntity<StandardResponse<AccommodationPageResponse>> getAccommodationByTableIdAndUserId(
 		@RequestParam Integer tableId,
 		@RequestParam Integer page,
-		@RequestParam Integer size
+		@RequestParam Integer size,
+		@RequestParam (required = false) Long userId
 	) {
-		AccommodationPageResponse response = accommodationService.findAccommodationsByTableId(tableId, page, size);
+		AccommodationPageResponse response = accommodationService.findAccommodationsByTableId(tableId, page, size, userId);
 		return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
 	}
 }

--- a/src/main/java/com/yapp/backend/controller/docs/AccommodationDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/AccommodationDocs.java
@@ -6,9 +6,7 @@ import com.yapp.backend.controller.dto.response.AccommodationPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.http.ResponseEntity;
@@ -16,10 +14,10 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "숙소 API", description = "숙소 관련 API")
 public interface AccommodationDocs {
 	@Operation(summary = "숙소 목록 조회", description = "숙소 목록을 조회합니다.")
-	@ApiResponse(responseCode = "200", description = "숙소 목록 조회 성공", content = @Content(schema = @Schema(implementation = StandardResponse.class)))
-	ResponseEntity<StandardResponse<AccommodationPageResponse>> getAccommodationsByTitle(
-		@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer", description = "숙소가 포함된 테이블의 ID")) Integer tableId,
-		@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer", description = "페이지 번호")) Integer page,
-		@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer", description = "페이지 크기")) Integer size
+	ResponseEntity<StandardResponse<AccommodationPageResponse>> getAccommodationByTableIdAndUserId(
+		@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "숙소가 포함된 테이블의 ID") Integer tableId,
+		@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "페이지 번호") Integer page,
+		@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "페이지 크기") Integer size,
+		@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int64"), description = "유저 ID, 없는 경우 모든 유저가 생성한 숙소 목록을 반환합니다.") Long userId
 	);
 }

--- a/src/main/java/com/yapp/backend/controller/dto/response/AccommodationResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/AccommodationResponse.java
@@ -5,6 +5,7 @@ import com.yapp.backend.service.model.Amenity;
 import com.yapp.backend.service.model.Attraction;
 import com.yapp.backend.service.model.CheckTime;
 import com.yapp.backend.service.model.Transportation;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,59 +19,61 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AccommodationResponse {
-    private Long id;
-    private String urlTest;
-    private String siteName;
-    private String memo;
-    private LocalDate createdAt;
-    private LocalDate updatedAt;
-    private Long createdBy;
-    private Long tableId;
-    private String accommodationName;
-    private List<String> images;
-    private String address;
-    private Double latitude;
-    private Double longitude;
-    private Integer lowestPrice;
-    private Integer highestPrice;
-    private String currency;
-    private Double reviewScore;
-    private Double cleanlinessScore;
-    private String reviewSummary;
-    private Long hotelId;
-    private List<Attraction> nearbyAttractions;
-    private List<Transportation> nearbyTransportation;
-    private List<Amenity> amenities;
-    private CheckTime checkInTime;
-    private CheckTime checkOutTime;
+	private Long id;
+	private Long userId;
+	private String urlTest;
+	private String siteName;
+	private String memo;
+	private LocalDate createdAt;
+	private LocalDate updatedAt;
+	private Long createdBy;
+	private Long tableId;
+	private String accommodationName;
+	private List<String> images;
+	private String address;
+	private Double latitude;
+	private Double longitude;
+	private Integer lowestPrice;
+	private Integer highestPrice;
+	private String currency;
+	private Double reviewScore;
+	private Double cleanlinessScore;
+	private String reviewSummary;
+	private Long hotelId;
+	private List<Attraction> nearbyAttractions;
+	private List<Transportation> nearbyTransportation;
+	private List<Amenity> amenities;
+	private CheckTime checkInTime;
+	private CheckTime checkOutTime;
 
-    public static AccommodationResponse from(Accommodation accommodation) {
-        return AccommodationResponse.builder()
-                .id(accommodation.getId())
-                .urlTest(accommodation.getUrlTest())
-                .siteName(accommodation.getSiteName())
-                .memo(accommodation.getMemo())
-                .createdAt(accommodation.getCreatedAt())
-                .updatedAt(accommodation.getUpdatedAt())
-                .createdBy(accommodation.getCreatedBy())
-                .tableId(accommodation.getTableId())
-                .accommodationName(accommodation.getAccommodationName())
-                .images(accommodation.getImages())
-                .address(accommodation.getAddress())
-                .latitude(accommodation.getLatitude())
-                .longitude(accommodation.getLongitude())
-                .lowestPrice(accommodation.getLowestPrice())
-                .highestPrice(accommodation.getHighestPrice())
-                .currency(accommodation.getCurrency())
-                .reviewScore(accommodation.getReviewScore())
-                .cleanlinessScore(accommodation.getCleanlinessScore())
-                .reviewSummary(accommodation.getReviewSummary())
-                .hotelId(accommodation.getHotelId())
-                .nearbyAttractions(accommodation.getNearbyAttractions())
-                .nearbyTransportation(accommodation.getNearbyTransportation())
-                .amenities(accommodation.getAmenities())
-                .checkInTime(accommodation.getCheckInTime())
-                .checkOutTime(accommodation.getCheckOutTime())
-                .build();
-    }
+	public static AccommodationResponse from(Accommodation accommodation) {
+		return AccommodationResponse.builder()
+			.userId(accommodation.getUserId())
+			.id(accommodation.getId())
+			.urlTest(accommodation.getUrlTest())
+			.siteName(accommodation.getSiteName())
+			.memo(accommodation.getMemo())
+			.createdAt(accommodation.getCreatedAt())
+			.updatedAt(accommodation.getUpdatedAt())
+			.createdBy(accommodation.getCreatedBy())
+			.tableId(accommodation.getTableId())
+			.accommodationName(accommodation.getAccommodationName())
+			.images(accommodation.getImages())
+			.address(accommodation.getAddress())
+			.latitude(accommodation.getLatitude())
+			.longitude(accommodation.getLongitude())
+			.lowestPrice(accommodation.getLowestPrice())
+			.highestPrice(accommodation.getHighestPrice())
+			.currency(accommodation.getCurrency())
+			.reviewScore(accommodation.getReviewScore())
+			.cleanlinessScore(accommodation.getCleanlinessScore())
+			.reviewSummary(accommodation.getReviewSummary())
+			.hotelId(accommodation.getHotelId())
+			.nearbyAttractions(accommodation.getNearbyAttractions())
+			.nearbyTransportation(accommodation.getNearbyTransportation())
+			.amenities(accommodation.getAmenities())
+			.checkInTime(accommodation.getCheckInTime())
+			.checkOutTime(accommodation.getCheckOutTime())
+			.build();
+	}
 }

--- a/src/main/java/com/yapp/backend/repository/AccommodationRepository.java
+++ b/src/main/java/com/yapp/backend/repository/AccommodationRepository.java
@@ -1,8 +1,4 @@
 package com.yapp.backend.repository;
 
-import com.yapp.backend.repository.entity.AccommodationEntity;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface AccommodationRepository extends JpaRepository<AccommodationEntity, Long> {
+public interface AccommodationRepository {
 }

--- a/src/main/java/com/yapp/backend/repository/JpaAccommodationRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaAccommodationRepository.java
@@ -1,0 +1,8 @@
+package com.yapp.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.yapp.backend.repository.entity.AccommodationEntity;
+
+public interface JpaAccommodationRepository extends JpaRepository<AccommodationEntity, Long> {
+}

--- a/src/main/java/com/yapp/backend/repository/impl/AccommodationRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/AccommodationRepositoryImpl.java
@@ -1,0 +1,14 @@
+package com.yapp.backend.repository.impl;
+
+import org.springframework.stereotype.Repository;
+
+import com.yapp.backend.repository.AccommodationRepository;
+import com.yapp.backend.repository.JpaAccommodationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AccommodationRepositoryImpl implements AccommodationRepository {
+	private final JpaAccommodationRepository jpaAccommodationRepository;
+}

--- a/src/main/java/com/yapp/backend/service/AccommodationService.java
+++ b/src/main/java/com/yapp/backend/service/AccommodationService.java
@@ -3,5 +3,5 @@ package com.yapp.backend.service;
 import com.yapp.backend.controller.dto.response.AccommodationPageResponse;
 
 public interface AccommodationService {
-    AccommodationPageResponse findAccommodationsByTableId(Integer tableId, int page, int size);
+    AccommodationPageResponse findAccommodationsByTableId(Integer tableId, int page, int size, Long userId);
 }

--- a/src/main/java/com/yapp/backend/service/impl/AccommodationServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/AccommodationServiceImpl.java
@@ -5,7 +5,7 @@ import com.yapp.backend.repository.AccommodationRepository;
 import com.yapp.backend.service.model.Amenity;
 import com.yapp.backend.service.model.Attraction;
 import com.yapp.backend.service.model.CheckTime;
-import com.yapp.backend.repository.entity.DistanceInfo;
+import com.yapp.backend.service.model.DistanceInfo;
 import com.yapp.backend.service.model.Transportation;
 import com.yapp.backend.service.AccommodationService;
 
@@ -19,14 +19,22 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * 숙소 도메인 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class AccommodationServiceImpl implements AccommodationService {
 
 	private final AccommodationRepository accommodationRepository;
 
+	/**
+	 * 숙소 목록 조회
+	 * 특정 유저가 생성한 숙소 목록을 조회
+	 * userId 가 null인 경우, 그룹에 속한 모든 숙소를 조회
+	 */
 	@Override
-	public AccommodationPageResponse findAccommodationsByTableId(Integer tableId, int page, int size) {
+	public AccommodationPageResponse findAccommodationsByTableId(Integer tableId, int page, int size, Long userId) {
 		// Base coordinates for Seoul
 		double baseLatitude = 37.5665;
 		double baseLongitude = 126.9780;
@@ -55,6 +63,10 @@ public class AccommodationServiceImpl implements AccommodationService {
 			.build();
 	}
 
+	/**
+	 * Mock Method
+	 * @sehwan 실제 API로 변경되면 제거해야 합니다.
+	 */
 	private Accommodation createMockAccommodation(Long id, String name, String address, double latitude, double longitude) {
 		return Accommodation.builder()
 			.id(id)
@@ -86,6 +98,10 @@ public class AccommodationServiceImpl implements AccommodationService {
 			.build();
 	}
 
+	/**
+	 * Mock Method
+	 * @sehwan 실제 API로 변경되면 제거해야 합니다.
+	 */
 	private List<Attraction> createRandomAttractions() {
 		return List.of(
 			Attraction.builder().name("Namsan Tower").type("Landmark").latitude(37.5512).longitude(126.9882).distance("5km").byFoot(new DistanceInfo("60min", "5km")).byCar(new DistanceInfo("15min", "5km")).build(),
@@ -93,6 +109,10 @@ public class AccommodationServiceImpl implements AccommodationService {
 		);
 	}
 
+	/**
+	 * Mock Method
+	 * @sehwan 실제 API로 변경되면 제거해야 합니다.
+	 */
 	private List<Transportation> createRandomTransportations() {
 		return List.of(
 			Transportation.builder().name("Seoul Station").type("Train Station").latitude(37.5559).longitude(126.9723).distance("2km").byFoot(new DistanceInfo("20min", "2km")).byCar(new DistanceInfo("5min", "2km")).build(),

--- a/src/main/java/com/yapp/backend/service/model/Accommodation.java
+++ b/src/main/java/com/yapp/backend/service/model/Accommodation.java
@@ -14,6 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 public class Accommodation {
     private Long id;
+    private Long userId;
     private String urlTest;
     private String siteName;
     private String memo;

--- a/src/main/java/com/yapp/backend/service/model/Attraction.java
+++ b/src/main/java/com/yapp/backend/service/model/Attraction.java
@@ -1,7 +1,5 @@
 package com.yapp.backend.service.model;
 
-import com.yapp.backend.repository.entity.DistanceInfo;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/yapp/backend/service/model/DistanceInfo.java
+++ b/src/main/java/com/yapp/backend/service/model/DistanceInfo.java
@@ -1,4 +1,4 @@
-package com.yapp.backend.repository.entity;
+package com.yapp.backend.service.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/yapp/backend/service/model/Transportation.java
+++ b/src/main/java/com/yapp/backend/service/model/Transportation.java
@@ -1,7 +1,5 @@
 package com.yapp.backend.service.model;
 
-import com.yapp.backend.repository.entity.DistanceInfo;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/Y26W2-132 -> main

### 변경 사항
- userId로 필터링 할 수 있도록 기능을 추가합니다.

### PR 체크리스트
- [ ] 테스트 통과 여부
- [ ] merge branch 확인 여부

### 추가 전달 사항
<img width="960" height="905" alt="image" src="https://github.com/user-attachments/assets/4028bf92-8cfd-4c31-8700-7a9cd232e3f8" />

### 테스트 결과

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 숙소 응답에 userId 필드가 추가되어 각 숙소의 작성자 정보를 확인할 수 있습니다.
  * 숙소 목록 조회 시 userId 파라미터를 선택적으로 전달하여 특정 사용자가 등록한 숙소만 조회할 수 있습니다.

* **Documentation**
  * 표준 응답 및 숙소 관련 API에 대한 Swagger/OpenAPI 문서 설명이 추가되어 API 사용성이 향상되었습니다.

* **Refactor**
  * 숙소 레포지토리 구조가 개선되어 내부 관리가 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->