### PR TITLE
[Y26W2-165] swagger 접속 안되는 오류 해결

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -3,7 +3,7 @@ name: CI/CD Pipeline
 on:
   push:
     branches:
-      - hotfix/Y26W2-165
+      - main
 
 env:
   SA_KEY: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -3,7 +3,7 @@ name: CI/CD Pipeline
 on:
   push:
     branches:
-      - main
+      - hotfix/Y26W2-165
 
 env:
   SA_KEY: ${{ secrets.GCP_SA_KEY }}

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -40,6 +40,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 || uri.equals("/")
                 || uri.startsWith("/error")
                 || uri.startsWith("/swagger")
+                || uri.startsWith("/v3/api-docs")
                 ;
     }
 

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -41,7 +41,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 || uri.startsWith("/error")
                 || uri.startsWith("/swagger")
                 || uri.startsWith("/v3/api-docs")
-                || uri.startsWith("/api/oauth/kakao")
+                || uri.startsWith("/api/oauth")
                 ;
     }
 

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -41,6 +41,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 || uri.startsWith("/error")
                 || uri.startsWith("/swagger")
                 || uri.startsWith("/v3/api-docs")
+                || uri.startsWith("/api/oauth/kakao")
                 ;
     }
 


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- jwtFilter 허용 Uri 목록에 /v3/api-docs 추가

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [ ] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [ ] 컨벤션 규칙을 지켰나요?
- [ ] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * "/v3/api-docs" 및 "/api/oauth" 경로에 대한 요청이 JWT 인증 필터를 우회하도록 개선되었습니다.
  * CI/CD 파이프라인이 "hotfix/Y26W2-165" 브랜치에 푸시될 때 자동으로 실행되도록 워크플로우가 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->