### PR TITLE
[Y26W2-249] 숙소 등록 API 여행 보드 관련 로직 수정

### DIFF
--- a/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 
     // Authorization
     INVALID_USER_AUTHORIZATION("사용자 권한 없음", "해당 권한이 없는 유저입니다.", HttpStatus.FORBIDDEN),
+    USER_AUTHORIZATION_FAILED("사용자 권한 없음", "해당 리소스에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
     // Accommodation related errors
     INVALID_TABLE_ID("잘못된 테이블 ID", "존재하지 않거나 유효하지 않은 테이블 ID입니다.", HttpStatus.BAD_REQUEST),
@@ -47,7 +48,8 @@ public enum ErrorCode {
     OAUTH_CLIENT_AUTH_ERROR("OAuth 클라이언트 인증 오류", "OAuth 클라이언트 인증에 실패했습니다. 클라이언트 정보를 확인해 주세요.", HttpStatus.UNAUTHORIZED),
     OAUTH_TOKEN_EXCHANGE_FAILED("OAuth 토큰 교환 실패", "OAuth 토큰 교환 과정에서 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),
     INVALID_OAUTH_BASE_URL("허용되지 않은 Base URL", "OAuth 요청에서 허용되지 않은 Base URL입니다.", HttpStatus.FORBIDDEN),
-    UNSUPPORTED_OAUTH_PROVIDER("지원하지 않는 OAuth 공급자", "요청한 OAuth 공급자는 현재 지원되지 않습니다. 지원 가능한 공급자를 확인해 주세요.", HttpStatus.BAD_REQUEST)
+    UNSUPPORTED_OAUTH_PROVIDER("지원하지 않는 OAuth 공급자", "요청한 OAuth 공급자는 현재 지원되지 않습니다. 지원 가능한 공급자를 확인해 주세요.",
+            HttpStatus.BAD_REQUEST)
     // 필요에 따라 추가
     ;
 

--- a/src/main/java/com/yapp/backend/common/exception/UserAuthorizationException.java
+++ b/src/main/java/com/yapp/backend/common/exception/UserAuthorizationException.java
@@ -1,8 +1,36 @@
 package com.yapp.backend.common.exception;
 
+/**
+ * 사용자 권한 검증 실패 시 발생하는 예외
+ * 사용자가 특정 리소스(여행보드, 숙소 등)에 접근할 권한이 없을 때 사용
+ */
 public class UserAuthorizationException extends CustomException {
 
     public UserAuthorizationException(ErrorCode errorCode) {
         super(errorCode);
+    }
+
+    public UserAuthorizationException() {
+        super(ErrorCode.USER_AUTHORIZATION_FAILED);
+    }
+
+    public UserAuthorizationException(String message) {
+        super(ErrorCode.USER_AUTHORIZATION_FAILED, message);
+    }
+
+    /**
+     * 사용자 ID와 보드 ID를 포함한 상세 메시지로 예외 생성
+     */
+    public UserAuthorizationException(Long userId, Long boardId) {
+        super(ErrorCode.USER_AUTHORIZATION_FAILED,
+                String.format("사용자 %d는 보드 %d에 접근 권한이 없습니다", userId, boardId));
+    }
+
+    /**
+     * 사용자 ID와 숙소 ID를 포함한 상세 메시지로 예외 생성
+     */
+    public static UserAuthorizationException forAccommodation(Long userId, Long accommodationId) {
+        return new UserAuthorizationException(
+                String.format("사용자 %d는 숙소 %d에 접근 권한이 없습니다", userId, accommodationId));
     }
 }

--- a/src/main/java/com/yapp/backend/controller/AccommodationController.java
+++ b/src/main/java/com/yapp/backend/controller/AccommodationController.java
@@ -8,11 +8,15 @@ import com.yapp.backend.controller.dto.response.AccommodationCountResponse;
 import com.yapp.backend.controller.dto.response.AccommodationPageResponse;
 import com.yapp.backend.controller.dto.response.AccommodationRegisterResponse;
 import com.yapp.backend.controller.dto.response.AccommodationResponse;
+import com.yapp.backend.filter.dto.CustomUserDetails;
 import com.yapp.backend.service.AccommodationService;
+import com.yapp.backend.service.UserTripBoardAuthorizationService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,67 +29,155 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 숙소 도메인 Controller
  */
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/accommodations")
 @Validated
 public class AccommodationController implements AccommodationDocs {
 
-	private final AccommodationService accommodationService;
+    private final AccommodationService accommodationService;
+    private final UserTripBoardAuthorizationService authorizationService;
 
-	/**
-	 * 숙소 목록 조회 API
-	 * todo sehwan 그룹에 속한 userId 만 조회할 수 있도록 로직 필요
-	 */
-	@Override
-	@GetMapping("/search")
-	public ResponseEntity<StandardResponse<AccommodationPageResponse>> getAccommodationByBoardIdAndUserId(
-			@RequestParam Long boardId,
-			@RequestParam Integer page,
-			@RequestParam Integer size,
-			@RequestParam(required = false) Long userId,
-			@RequestParam(defaultValue = "saved_at_desc") String sort) {
+    /**
+     * 숙소 목록 조회 API
+     * 인증된 사용자가 속한 여행보드의 숙소 목록만 조회할 수 있습니다.
+     */
+    @Override
+    @GetMapping("/search")
+    public ResponseEntity<StandardResponse<AccommodationPageResponse>> getAccommodationByBoardIdAndUserId(
+            @RequestParam Long boardId,
+            @RequestParam Integer page,
+            @RequestParam Integer size,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(defaultValue = "saved_at_desc") String sort,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-		AccommodationPageResponse response = accommodationService.findAccommodationsByBoardId(boardId, page, size,
-				userId, sort);
-		return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
-	}
+        Long whoAmI = userDetails.getUserId();
 
-	/**
-	 * 숙소 개수 조회 API
-	 * todo sehwan 그룹에 속한 userId 만 조회할 수 있도록 로직 필요
-	 */
-	@Override
-	@GetMapping("/count")
-	public ResponseEntity<StandardResponse<AccommodationCountResponse>> getAccommodationCountByBoardId(
-			@RequestParam Long boardId,
-			@RequestParam(required = false) Long userId) {
-		AccommodationCountResponse accommodationCountResponse = new AccommodationCountResponse(
-				accommodationService.countAccommodationsByBoardId(boardId, userId));
-		return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, accommodationCountResponse));
-	}
+        try {
+            // 1. 현재 사용자의 boardId 접근 권한 확인
+            log.debug("숙소 목록 조회 권한 검증 시작 - 요청자: {}, 보드ID: {}", whoAmI, boardId);
+            authorizationService.validateTripBoardAccess(whoAmI, boardId);
 
-	/**
-	 * 숙소 카드 등록 API
-	 * todo sehwan 그룹에 속한 userId 만 등록할 수 있도록 로직 필요
-	 */
-	@Override
-	@PostMapping("/register")
-	public ResponseEntity<StandardResponse<AccommodationRegisterResponse>> registerAccommodationCard(
-			@RequestBody AccommodationRegisterRequest request) {
-		AccommodationRegisterResponse response = accommodationService.registerAccommodationCard(request);
-		return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
-	}
+            // 2. userId 파라미터가 있는 경우 해당 사용자의 권한도 확인
+            if (userId != null) {
+                log.debug("대상 사용자 권한 검증 시작 - 대상사용자: {}, 보드ID: {}", userId, boardId);
+                authorizationService.validateTripBoardAccess(userId, boardId);
+            }
 
-	/**
-	 * 숙소 단건 조회 API
-	 * 특정 숙소 ID로 숙소 정보를 조회합니다.
-	 */
-	@Override
-	@GetMapping("/{accommodationId}")
-	public ResponseEntity<StandardResponse<AccommodationResponse>> getAccommodationById(
-			@PathVariable Long accommodationId) {
-		AccommodationResponse response = accommodationService.findAccommodationById(accommodationId);
-		return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
-	}
+            // 3. 권한 확인 후 기존 로직 실행
+            AccommodationPageResponse response = accommodationService.findAccommodationsByBoardId(boardId, page, size,
+                    userId, sort);
+
+            return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
+
+        } catch (Exception e) {
+            log.error("숙소 목록 조회 API 실패 - 요청자: {}, 보드ID: {}, 오류: {}",
+                    whoAmI, boardId, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * 숙소 개수 조회 API
+     * 인증된 사용자가 속한 여행보드의 숙소 개수만 조회할 수 있습니다.
+     */
+    @Override
+    @GetMapping("/count")
+    public ResponseEntity<StandardResponse<AccommodationCountResponse>> getAccommodationCountByBoardId(
+            @RequestParam Long boardId,
+            @RequestParam(required = false) Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long whoAmI = userDetails.getUserId();
+
+        try {
+            // 1. 현재 사용자의 boardId 접근 권한 확인
+            log.debug("숙소 개수 조회 권한 검증 시작 - 요청자: {}, 보드ID: {}", whoAmI, boardId);
+            authorizationService.validateTripBoardAccess(whoAmI, boardId);
+
+            // 2. userId 파라미터가 있는 경우 해당 사용자의 권한도 확인
+            if (userId != null) {
+                log.debug("대상 사용자 권한 검증 시작 - 대상사용자: {}, 보드ID: {}", userId, boardId);
+                authorizationService.validateTripBoardAccess(userId, boardId);
+            }
+
+            // 3. 권한 확인 후 기존 로직 실행
+            Long count = accommodationService.countAccommodationsByBoardId(boardId, userId);
+            AccommodationCountResponse accommodationCountResponse = new AccommodationCountResponse(count);
+
+            log.info("숙소 개수 조회 API 성공 - 요청자: {}, 보드ID: {}, 개수: {}", whoAmI, boardId, count);
+
+            return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, accommodationCountResponse));
+
+        } catch (Exception e) {
+            log.error("숙소 개수 조회 API 실패 - 요청자: {}, 보드ID: {}, 오류: {}", whoAmI, boardId, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * 숙소 카드 등록 API
+     * 인증된 사용자가 속한 여행보드에만 숙소를 등록할 수 있습니다.
+     */
+    @Override
+    @PostMapping("/register")
+    public ResponseEntity<StandardResponse<AccommodationRegisterResponse>> registerAccommodationCard(
+            @RequestBody AccommodationRegisterRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long whoAmI = userDetails.getUserId();
+
+        try {
+            // 1. 현재 사용자의 boardId 접근 권한 확인
+            log.debug("숙소 등록 권한 검증 시작 - 요청자: {}, 보드ID: {}", whoAmI, request.getBoardId());
+            authorizationService.validateTripBoardAccess(whoAmI, request.getBoardId());
+
+            // 2. 권한 확인 후 사용자 ID를 포함하여 숙소 등록
+            AccommodationRegisterResponse response = accommodationService.registerAccommodationCard(request, whoAmI);
+
+            log.info("숙소 등록 API 성공 - 요청자: {}, 보드ID: {}, 등록된숙소ID: {}",
+                    whoAmI, request.getBoardId(), response.getAccommodationId());
+
+            return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
+
+        } catch (Exception e) {
+            log.error("숙소 등록 API 실패 - 요청자: {}, 보드ID: {}, 오류: {}",
+                    whoAmI, request.getBoardId(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * 숙소 단건 조회 API
+     * 인증된 사용자가 속한 여행보드의 숙소만 조회할 수 있습니다.
+     */
+    @Override
+    @GetMapping("/{accommodationId}")
+    public ResponseEntity<StandardResponse<AccommodationResponse>> getAccommodationById(
+            @PathVariable Long accommodationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long whoAmI = userDetails.getUserId();
+
+        try {
+            // 1. 현재 사용자의 해당 숙소 접근 권한 확인
+            log.debug("숙소 단건 조회 권한 검증 시작 - 요청자: {}, 숙소ID: {}", whoAmI, accommodationId);
+            authorizationService.validateAccommodationAccess(whoAmI, accommodationId);
+
+            // 2. 권한 확인 후 기존 로직 실행
+            AccommodationResponse response = accommodationService.findAccommodationById(accommodationId);
+
+            log.info("숙소 단건 조회 API 성공 - 요청자: {}, 숙소ID: {}, 숙소명: {}",
+                    whoAmI, accommodationId, response.getAccommodationName());
+
+            return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
+
+        } catch (Exception e) {
+            log.error("숙소 단건 조회 API 실패 - 요청자: {}, 숙소ID: {}, 오류: {}",
+                    whoAmI, accommodationId, e.getMessage(), e);
+            throw e;
+        }
+    }
 }

--- a/src/main/java/com/yapp/backend/controller/docs/AccommodationDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/AccommodationDocs.java
@@ -7,6 +7,7 @@ import com.yapp.backend.controller.dto.response.AccommodationPageResponse;
 import com.yapp.backend.controller.dto.response.AccommodationRegisterResponse;
 import com.yapp.backend.controller.dto.response.AccommodationResponse;
 
+import com.yapp.backend.filter.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -18,6 +19,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 @Tag(name = "숙소 API", description = "숙소 관련 API")
 public interface AccommodationDocs {
@@ -27,18 +29,22 @@ public interface AccommodationDocs {
 			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "페이지 번호") @NotNull(message = "페이지 번호는 필수입니다.") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.") Integer page,
 			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "페이지 크기") @NotNull(message = "페이지 크기는 필수입니다.") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") Integer size,
 			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int64"), description = "유저 ID, 없는 경우 모든 유저가 생성한 숙소 목록을 반환합니다. 현재 parameter로 받는 것은 임시 로직입니다.") Long userId,
-			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "string"), description = "정렬 기준, 기본 값은 saved_at_desc(최근 등록순)이고, price_asc(최저 가격순)을 제공합니다.") String sort);
+			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "string"), description = "정렬 기준, 기본 값은 saved_at_desc(최근 등록순)이고, price_asc(최저 가격순)을 제공합니다.") String sort,
+			@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
 	@Operation(summary = "여행보드 숙소 개수 조회", description = "여행보드에 포함된 숙소의 개수를 조회합니다.")
 	ResponseEntity<StandardResponse<AccommodationCountResponse>> getAccommodationCountByBoardId(
 			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int64"), description = "숙소가 포함된 여행보드의 ID") @Min(value = 1, message = "여행보드 ID는 1 이상이어야 합니다.") Long boardId,
-			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int64"), description = "유저 ID, 없는 경우 모든 유저가 생성한 숙소 목록을 반환합니다. 현재 parameter로 받는 것은 임시 로직입니다.") Long userId);
+			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int64"), description = "유저 ID, 없는 경우 모든 유저가 생성한 숙소 목록을 반환합니다. 현재 parameter로 받는 것은 임시 로직입니다.") Long userId,
+			@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
 	@Operation(summary = "숙소 카드 등록", description = "링크를 첨부하여 숙소 카드를 등록합니다.", method = "POST")
 	ResponseEntity<StandardResponse<AccommodationRegisterResponse>> registerAccommodationCard(
-			@RequestBody(description = "숙소 등록 요청 데이터", content = @Content(schema = @Schema(implementation = AccommodationRegisterRequest.class))) AccommodationRegisterRequest request);
+			@RequestBody(description = "숙소 등록 요청 데이터", content = @Content(schema = @Schema(implementation = AccommodationRegisterRequest.class))) AccommodationRegisterRequest request,
+			@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
 	@Operation(summary = "숙소 단건 조회", description = "특정 숙소 ID로 숙소 정보를 조회합니다.")
 	ResponseEntity<StandardResponse<AccommodationResponse>> getAccommodationById(
-			@Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer", format = "int64"), description = "조회할 숙소의 ID") @NotNull(message = "숙소 ID는 필수입니다.") @Min(value = 1, message = "숙소 ID는 1 이상이어야 합니다.") Long accommodationId);
+			@Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer", format = "int64"), description = "조회할 숙소의 ID") @NotNull(message = "숙소 ID는 필수입니다.") @Min(value = 1, message = "숙소 ID는 1 이상이어야 합니다.") Long accommodationId,
+			@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/com/yapp/backend/controller/dto/request/AccommodationRegisterRequest.java
+++ b/src/main/java/com/yapp/backend/controller/dto/request/AccommodationRegisterRequest.java
@@ -21,7 +21,4 @@ public class AccommodationRegisterRequest {
 	
 	@NotNull(message = "여행 보드 ID는 필수 입력값입니다.")
 	private Long boardId;
-	
-	@NotNull(message = "사용자 ID는 필수 입력값입니다.")
-	private Long userId;
 }

--- a/src/main/java/com/yapp/backend/service/AccommodationService.java
+++ b/src/main/java/com/yapp/backend/service/AccommodationService.java
@@ -12,9 +12,9 @@ public interface AccommodationService {
 
     Long countAccommodationsByBoardId(Long boardId, Long userId);
 
-    AccommodationRegisterResponse registerAccommodationCard(AccommodationRegisterRequest request);
+    AccommodationRegisterResponse registerAccommodationCard(AccommodationRegisterRequest request, Long userId);
 
     AccommodationResponse findAccommodationById(Long accommodationId);
-    
+
     void updateAccommodation(UpdateAccommodationRequest request);
 }

--- a/src/main/java/com/yapp/backend/service/UserTripBoardAuthorizationService.java
+++ b/src/main/java/com/yapp/backend/service/UserTripBoardAuthorizationService.java
@@ -4,12 +4,6 @@ package com.yapp.backend.service;
  * 사용자-여행보드 권한 검증을 위한 서비스 인터페이스
  */
 public interface UserTripBoardAuthorizationService {
-
-    /**
-     * 사용자가 특정 여행보드에 접근 권한이 있는지 확인
-     */
-    boolean hasAccessToTripBoard(Long userId, Long boardId);
-
     /**
      * 사용자의 여행보드 접근 권한을 검증하고, 권한이 없으면 예외 발생
      */

--- a/src/main/java/com/yapp/backend/service/UserTripBoardAuthorizationService.java
+++ b/src/main/java/com/yapp/backend/service/UserTripBoardAuthorizationService.java
@@ -1,0 +1,22 @@
+package com.yapp.backend.service;
+
+/**
+ * 사용자-여행보드 권한 검증을 위한 서비스 인터페이스
+ */
+public interface UserTripBoardAuthorizationService {
+
+    /**
+     * 사용자가 특정 여행보드에 접근 권한이 있는지 확인
+     */
+    boolean hasAccessToTripBoard(Long userId, Long boardId);
+
+    /**
+     * 사용자의 여행보드 접근 권한을 검증하고, 권한이 없으면 예외 발생
+     */
+    void validateTripBoardAccess(Long userId, Long boardId);
+
+    /**
+     * 사용자의 숙소 접근 권한을 검증하고, 권한이 없으면 예외 발생
+     */
+    void validateAccommodationAccess(Long userId, Long accommodationId);
+}

--- a/src/main/java/com/yapp/backend/service/impl/UserTripBoardAuthorizationServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/UserTripBoardAuthorizationServiceImpl.java
@@ -1,0 +1,112 @@
+package com.yapp.backend.service.impl;
+
+import com.yapp.backend.common.exception.UserAuthorizationException;
+import com.yapp.backend.repository.JpaAccommodationRepository;
+import com.yapp.backend.repository.JpaUserTripBoardRepository;
+import com.yapp.backend.repository.entity.AccommodationEntity;
+import com.yapp.backend.service.UserTripBoardAuthorizationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 사용자-여행보드 권한 검증 서비스 구현체
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserTripBoardAuthorizationServiceImpl implements UserTripBoardAuthorizationService {
+
+    private final JpaUserTripBoardRepository userTripBoardRepository;
+    private final JpaAccommodationRepository accommodationRepository;
+
+    @Override
+    public boolean hasAccessToTripBoard(Long userId, Long boardId) {
+        log.info("권한 검증 시작 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
+
+        if (userId == null || boardId == null) {
+            log.warn("권한 검증 실패 - 사유: null 파라미터, userId={}, boardId={}", userId, boardId);
+            return false;
+        }
+
+        try {
+            boolean hasAccess = userTripBoardRepository.findByUserIdAndTripBoardId(userId, boardId)
+                    .isPresent();
+
+            if (hasAccess) {
+                log.info("권한 검증 성공 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
+            } else {
+                log.warn("권한 검증 실패 - 사용자 ID: {}, 보드 ID: {}, 사유: 보드 멤버가 아님", userId, boardId);
+            }
+
+            return hasAccess;
+
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void validateTripBoardAccess(Long userId, Long boardId) {
+        log.info("여행보드 접근 권한 검증 시작 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
+
+        try {
+            if (!hasAccessToTripBoard(userId, boardId)) {
+                log.warn("권한 없는 여행보드 접근 시도 차단 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
+                throw new UserAuthorizationException(userId, boardId);
+            }
+
+            log.info("여행보드 접근 권한 검증 통과 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
+        } catch (UserAuthorizationException e) {
+            // 이미 로깅된 예외를 다시 던짐
+            throw e;
+        } catch (Exception e) {
+            log.error("여행보드 접근 권한 검증 중 예외 발생 - 사용자 ID: {}, 보드 ID: {}, 오류: {}",
+                    userId, boardId, e.getMessage(), e);
+            throw new UserAuthorizationException(userId, boardId);
+        }
+    }
+
+    @Override
+    public void validateAccommodationAccess(Long userId, Long accommodationId) {
+        log.info("숙소 접근 권한 검증 시작 - 사용자 ID: {}, 숙소 ID: {}", userId, accommodationId);
+
+        if (userId == null || accommodationId == null) {
+            log.warn("숙소 접근 권한 검증 실패 - 사유: null 파라미터, userId={}, accommodationId={}",
+                    userId, accommodationId);
+            throw UserAuthorizationException.forAccommodation(userId, accommodationId);
+        }
+
+        try {
+            // 1. 숙소 정보 조회
+            AccommodationEntity accommodation = accommodationRepository.findByAccommodationId(accommodationId);
+            if (accommodation == null) {
+                log.warn("숙소 접근 권한 검증 실패 - 사유: 숙소를 찾을 수 없음, accommodationId={}", accommodationId);
+                throw UserAuthorizationException.forAccommodation(userId, accommodationId);
+            }
+
+            // 2. 해당 숙소가 속한 보드에 대한 사용자 권한 확인
+            Long boardId = accommodation.getBoardId();
+            boolean hasAccess = hasAccessToTripBoard(userId, boardId);
+
+            if (!hasAccess) {
+                log.warn("숙소 접근 권한 검증 실패 - 사용자 ID: {}, 숙소 ID: {}, 보드 ID: {}",
+                        userId, accommodationId, boardId);
+                throw UserAuthorizationException.forAccommodation(userId, accommodationId);
+            }
+
+            log.info("숙소 접근 권한 검증 성공 - 사용자 ID: {}, 숙소 ID: {}, 보드 ID: {}",
+                    userId, accommodationId, boardId);
+
+        } catch (UserAuthorizationException e) {
+            // 이미 로깅된 예외를 다시 던짐
+            throw e;
+        } catch (Exception e) {
+            log.error("숙소 접근 권한 검증 중 예외 발생 - 사용자 ID: {}, 숙소 ID: {}, 오류: {}",
+                    userId, accommodationId, e.getMessage(), e);
+            throw UserAuthorizationException.forAccommodation(userId, accommodationId);
+        }
+    }
+}

--- a/src/main/java/com/yapp/backend/service/impl/UserTripBoardAuthorizationServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/UserTripBoardAuthorizationServiceImpl.java
@@ -23,32 +23,6 @@ public class UserTripBoardAuthorizationServiceImpl implements UserTripBoardAutho
     private final JpaAccommodationRepository accommodationRepository;
 
     @Override
-    public boolean hasAccessToTripBoard(Long userId, Long boardId) {
-        log.info("권한 검증 시작 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
-
-        if (userId == null || boardId == null) {
-            log.warn("권한 검증 실패 - 사유: null 파라미터, userId={}, boardId={}", userId, boardId);
-            return false;
-        }
-
-        try {
-            boolean hasAccess = userTripBoardRepository.findByUserIdAndTripBoardId(userId, boardId)
-                    .isPresent();
-
-            if (hasAccess) {
-                log.info("권한 검증 성공 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
-            } else {
-                log.warn("권한 검증 실패 - 사용자 ID: {}, 보드 ID: {}, 사유: 보드 멤버가 아님", userId, boardId);
-            }
-
-            return hasAccess;
-
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    @Override
     public void validateTripBoardAccess(Long userId, Long boardId) {
         log.info("여행보드 접근 권한 검증 시작 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
 
@@ -107,6 +81,31 @@ public class UserTripBoardAuthorizationServiceImpl implements UserTripBoardAutho
             log.error("숙소 접근 권한 검증 중 예외 발생 - 사용자 ID: {}, 숙소 ID: {}, 오류: {}",
                     userId, accommodationId, e.getMessage(), e);
             throw UserAuthorizationException.forAccommodation(userId, accommodationId);
+        }
+    }
+
+    private boolean hasAccessToTripBoard(Long userId, Long boardId) {
+        log.info("권한 검증 시작 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
+
+        if (userId == null || boardId == null) {
+            log.warn("권한 검증 실패 - 사유: null 파라미터, userId={}, boardId={}", userId, boardId);
+            return false;
+        }
+
+        try {
+            boolean hasAccess = userTripBoardRepository.findByUserIdAndTripBoardId(userId, boardId)
+                    .isPresent();
+
+            if (hasAccess) {
+                log.info("권한 검증 성공 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
+            } else {
+                log.warn("권한 검증 실패 - 사용자 ID: {}, 보드 ID: {}, 사유: 보드 멤버가 아님", userId, boardId);
+            }
+
+            return hasAccess;
+
+        } catch (Exception e) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [X] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
숙소 카드를 등록하는 사용자의 인증정보를 이용하여 권한 체크

### PR 체크리스트
- [X] 정상적으로 실행이 되나요?
- [X] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [ ] 컨벤션 규칙을 지켰나요?
- [ ] merge branch 를 확인했나요?


### 추가 전달 사항
여행 보드에 포함된 사용자가 아니면 숙소 카드와 관련된 로직을 수행할 수 없도록 비즈니스 로직을 변경하였습니다.

### 테스트 결과

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * 숙소 관련 모든 API에 사용자 권한 검증이 추가되어, 인증된 사용자만 접근 및 등록이 가능해졌습니다.
  * 사용자 권한 예외 및 OAuth 예외에 대한 상세 에러 메시지와 응답이 제공됩니다.

* **Bug Fixes**
  * 숙소 등록 요청 시 사용자 ID를 별도로 입력할 필요가 없어졌습니다.

* **Documentation**
  * 인증 사용자 정보 파라미터가 API 문서에 반영되었습니다.

* **Chores**
  * 권한 검증을 위한 서비스 및 예외 처리 로직이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->