### PR TITLE
[Y26W-251] 액세스 토큰 전달 방식을 헤더로 변경

### DIFF
--- a/src/main/java/com/yapp/backend/common/util/JwtTokenProvider.java
+++ b/src/main/java/com/yapp/backend/common/util/JwtTokenProvider.java
@@ -1,5 +1,7 @@
 package com.yapp.backend.common.util;
 
+import static com.yapp.backend.filter.JwtFilter.REFRESH_TOKEN_COOKIE;
+
 import com.yapp.backend.filter.dto.CustomUserDetails;
 import com.yapp.backend.filter.service.RefreshTokenService;
 import io.jsonwebtoken.Claims;
@@ -27,8 +29,6 @@ import java.util.List;
 public class JwtTokenProvider {
 
     private static final long MILLISECONDS_PER_SECOND = 1_000L;
-    private static final String COOKIE_ACCESS_TOKEN = "ACCESS_TOKEN";
-    private static final String COOKIE_REFRESH_TOKEN = "REFRESH_TOKEN";
     private static final String COOKIE_PATH = "/";
     private static final String COOKIE_SAME_SITE = "Lax";
 
@@ -95,25 +95,6 @@ public class JwtTokenProvider {
     // ==================== 쿠키 생성 메서드 ====================
 
     /**
-     * Access Token 쿠키를 생성합니다.
-     *
-     * @param userId 사용자 ID
-     * @return Access Token ResponseCookie
-     */
-    public ResponseCookie generateAccessTokenCookie(Long userId) {
-        String accessToken = createAccessToken(userId);
-        long maxAgeInSeconds = accessTokenValidityInMs / MILLISECONDS_PER_SECOND;
-        
-        return ResponseCookie.from(COOKIE_ACCESS_TOKEN, accessToken)
-                .httpOnly(true)
-                .secure(true)
-                .path(COOKIE_PATH)
-                .maxAge(maxAgeInSeconds)
-                .sameSite(COOKIE_SAME_SITE)
-                .build();
-    }
-
-    /**
      * Refresh Token 쿠키를 생성하고 Redis에 저장합니다.
      *
      * @param userId 사용자 ID
@@ -126,7 +107,7 @@ public class JwtTokenProvider {
         // Redis에 Refresh Token 저장
         refreshTokenService.storeRefresh(userId, refreshToken);
         
-        return ResponseCookie.from(COOKIE_REFRESH_TOKEN, refreshToken)
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
                 .httpOnly(true)
                 .secure(true)
                 .path(COOKIE_PATH)

--- a/src/main/java/com/yapp/backend/common/util/TokenUtil.java
+++ b/src/main/java/com/yapp/backend/common/util/TokenUtil.java
@@ -1,0 +1,46 @@
+package com.yapp.backend.common.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Authorization 헤더에서 토큰을 추출하는 유틸리티 클래스
+ */
+@Slf4j
+public class TokenUtil {
+    
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    
+    /**
+     * Authorization 헤더에서 Bearer 토큰을 추출합니다.
+     * 
+     * @param request HTTP 요청
+     * @return 토큰 문자열, 없으면 null
+     */
+    public static String extractTokenFromHeader(HttpServletRequest request) {
+        String authHeader = request.getHeader(AUTHORIZATION_HEADER);
+        
+        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        
+        return authHeader.substring(BEARER_PREFIX.length());
+    }
+    
+    /**
+     * Refresh Token 헤더에서 토큰을 추출합니다.
+     * 
+     * @param request HTTP 요청
+     * @return 토큰 문자열, 없으면 null
+     */
+    public static String extractRefreshTokenFromHeader(HttpServletRequest request) {
+        String refreshHeader = request.getHeader("Refresh-Token");
+        
+        if (refreshHeader == null || refreshHeader.trim().isEmpty()) {
+            return null;
+        }
+        
+        return refreshHeader.trim();
+    }
+}

--- a/src/main/java/com/yapp/backend/common/util/TokenUtil.java
+++ b/src/main/java/com/yapp/backend/common/util/TokenUtil.java
@@ -28,19 +28,4 @@ public class TokenUtil {
         return authHeader.substring(BEARER_PREFIX.length());
     }
     
-    /**
-     * Refresh Token 헤더에서 토큰을 추출합니다.
-     * 
-     * @param request HTTP 요청
-     * @return 토큰 문자열, 없으면 null
-     */
-    public static String extractRefreshTokenFromHeader(HttpServletRequest request) {
-        String refreshHeader = request.getHeader("Refresh-Token");
-        
-        if (refreshHeader == null || refreshHeader.trim().isEmpty()) {
-            return null;
-        }
-        
-        return refreshHeader.trim();
-    }
 }

--- a/src/main/java/com/yapp/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/yapp/backend/config/SwaggerConfig.java
@@ -2,6 +2,8 @@ package com.yapp.backend.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
@@ -11,7 +13,13 @@ import org.springframework.context.annotation.Configuration;
                 description = "SSOK 서비스 API 명세"
         )
 )
+@SecurityScheme(
+        name = "JWT",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        description = "JWT Access Token을 Authorization 헤더로 전송"
+)
 @Configuration
 public class SwaggerConfig {
-
 }

--- a/src/main/java/com/yapp/backend/controller/OauthController.java
+++ b/src/main/java/com/yapp/backend/controller/OauthController.java
@@ -5,14 +5,14 @@ import static com.yapp.backend.common.response.ResponseType.*;
 import com.yapp.backend.common.response.StandardResponse;
 import com.yapp.backend.common.util.JwtTokenProvider;
 import com.yapp.backend.controller.docs.OauthDocs;
+import com.yapp.backend.filter.service.RefreshTokenService;
 import com.yapp.backend.controller.dto.response.AuthorizeUrlResponse;
 import com.yapp.backend.controller.dto.response.OauthLoginResponse;
 import com.yapp.backend.service.OauthService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +26,7 @@ public class OauthController implements OauthDocs {
 
     private final OauthService oauthService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     /**
      * 카카오 OAuth 인가 URL을 반환합니다.
@@ -60,15 +61,19 @@ public class OauthController implements OauthDocs {
         // 1. OAuth 인증 처리 및 사용자 정보 조회
         OauthLoginResponse oauthResponse = oauthService.exchangeCodeForToken("kakao", code, baseUrl);
         
-        // 2. 쿠키로 토큰 설정
-        ResponseCookie accessTokenCookie = jwtTokenProvider.generateAccessTokenCookie(oauthResponse.userId());
-        ResponseCookie refreshTokenCookie = jwtTokenProvider.generateRefreshTokenCookie(oauthResponse.userId());
+        // 2. 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(oauthResponse.userId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(oauthResponse.userId());
         
-        // 3. HTTP 응답에 쿠키 추가
-        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+        // 3. Redis에 Refresh Token 저장
+        refreshTokenService.storeRefresh(oauthResponse.userId(), refreshToken);
         
-        // 4. 사용자 정보만 응답 바디로 반환 (토큰은 쿠키로 전달됨)
+        // 4. HTTP 응답에 토큰 설정 (Access Token은 헤더, Refresh Token은 쿠키)
+        response.setHeader("Access-Token", accessToken);
+        ResponseCookie refreshCookie = jwtTokenProvider.generateRefreshTokenCookie(oauthResponse.userId());
+        response.addHeader("Set-Cookie", refreshCookie.toString());
+        
+        // 5. 사용자 정보만 응답 바디로 반환 (토큰은 헤더로 전달됨)
         return ResponseEntity.ok(new StandardResponse<>(SUCCESS, oauthResponse));
     }
     

--- a/src/main/java/com/yapp/backend/controller/OauthController.java
+++ b/src/main/java/com/yapp/backend/controller/OauthController.java
@@ -69,7 +69,7 @@ public class OauthController implements OauthDocs {
         refreshTokenService.storeRefresh(oauthResponse.userId(), refreshToken);
         
         // 4. HTTP 응답에 토큰 설정 (Access Token은 헤더, Refresh Token은 쿠키)
-        response.setHeader("Access-Token", accessToken);
+        response.setHeader("ACCESS_TOKEN", accessToken);
         ResponseCookie refreshCookie = jwtTokenProvider.generateRefreshTokenCookie(oauthResponse.userId());
         response.addHeader("Set-Cookie", refreshCookie.toString());
         

--- a/src/main/java/com/yapp/backend/controller/OauthController.java
+++ b/src/main/java/com/yapp/backend/controller/OauthController.java
@@ -65,6 +65,7 @@ public class OauthController implements OauthDocs {
         // 1. OAuth 인증 처리 및 사용자 정보 조회
         OauthLoginResponse oauthResponse = oauthService.exchangeCodeForToken("kakao", code, baseUrl);
 
+        // TODO: access, refresh 생성 메서드 재활용 가능하도록 리팩토링
         // 2. 토큰 생성
         String accessToken = jwtTokenProvider.createAccessToken(oauthResponse.userId());
         String refreshToken = jwtTokenProvider.createRefreshToken(oauthResponse.userId());

--- a/src/main/java/com/yapp/backend/controller/OauthController.java
+++ b/src/main/java/com/yapp/backend/controller/OauthController.java
@@ -1,6 +1,7 @@
 package com.yapp.backend.controller;
 
 import static com.yapp.backend.common.response.ResponseType.*;
+import static com.yapp.backend.filter.JwtFilter.ACCESS_TOKEN_HEADER;
 
 import com.google.common.net.HttpHeaders;
 import com.yapp.backend.common.response.StandardResponse;
@@ -28,9 +29,6 @@ public class OauthController implements OauthDocs {
     private final OauthService oauthService;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
-
-    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN";
-
 
     /**
      * 카카오 OAuth 인가 URL을 반환합니다.
@@ -74,7 +72,7 @@ public class OauthController implements OauthDocs {
         refreshTokenService.storeRefresh(oauthResponse.userId(), refreshToken);
         
         // 4. HTTP 응답에 토큰 설정 (Access Token은 헤더, Refresh Token은 쿠키)
-        response.setHeader(ACCESS_TOKEN_PREFIX, accessToken);
+        response.setHeader(ACCESS_TOKEN_HEADER, accessToken);
         ResponseCookie refreshCookie = jwtTokenProvider.generateRefreshTokenCookie(oauthResponse.userId());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
         

--- a/src/main/java/com/yapp/backend/controller/docs/AccommodationDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/AccommodationDocs.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -22,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "숙소 API", description = "숙소 관련 API")
 public interface AccommodationDocs {
 	@Operation(summary = "숙소 목록 조회", description = "숙소 목록을 조회합니다.")
+	@SecurityRequirement(name = "JWT")
 	ResponseEntity<StandardResponse<AccommodationPageResponse>> getAccommodationByBoardIdAndUserId(
 			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "숙소가 포함된 여행보드의 ID") @NotNull(message = "여행보드 ID는 필수입니다.") @Min(value = 1, message = "여행보드 ID는 1 이상이어야 합니다.") Long boardId,
 			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "페이지 번호") @NotNull(message = "페이지 번호는 필수입니다.") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.") Integer page,
@@ -30,6 +32,7 @@ public interface AccommodationDocs {
 			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "string"), description = "정렬 기준, 기본 값은 saved_at_desc(최근 등록순)이고, price_asc(최저 가격순)을 제공합니다.") String sort);
 
 	@Operation(summary = "여행보드 숙소 개수 조회", description = "여행보드에 포함된 숙소의 개수를 조회합니다.")
+	@SecurityRequirement(name = "JWT")
 	ResponseEntity<StandardResponse<AccommodationCountResponse>> getAccommodationCountByBoardId(
 			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int64"), description = "숙소가 포함된 여행보드의 ID") @Min(value = 1, message = "여행보드 ID는 1 이상이어야 합니다.") Long boardId,
 			@Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int64"), description = "유저 ID, 없는 경우 모든 유저가 생성한 숙소 목록을 반환합니다. 현재 parameter로 받는 것은 임시 로직입니다.") Long userId);

--- a/src/main/java/com/yapp/backend/controller/docs/ComparisonDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/ComparisonDocs.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,26 +29,30 @@ public interface ComparisonDocs {
     @Operation(summary = "편의 서비스 Enum 리스트", description = "편의 서비스 항목 Enum 리스트를 반환합니다.")
     ResponseEntity<StandardResponse<AmenityFactorList>> getAmenityFactorList();
 
-    @Operation(summary = "비교표 생성", description = "비교표 이름, 숙소 ID 리스트, 비교 기준 항목을 받아서 비교표 메타 데이터를 생성합니다.")
+    @Operation(summary = "비교표 생성", description = "비교표 이름, 숙소 ID 리스트, 비교 기준 항목을 받아서 비교표 메타 데이터를 생성합니다. (Authorization 헤더에 Bearer 토큰 필요)")
+    @SecurityRequirement(name = "JWT")
     ResponseEntity<StandardResponse<CreateComparisonTableResponse>> createComparisonTable(
             @RequestBody CreateComparisonTableRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
-    @Operation(summary = "비교표 조회", description = "비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다.")
+    @Operation(summary = "비교표 조회", description = "비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다. (Authorization 헤더에 Bearer 토큰 필요)")
+    @SecurityRequirement(name = "JWT")
     ResponseEntity<StandardResponse<ComparisonTableResponse>> getComparisonTable(
             @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "숙소가 포함된 테이블의 ID") Long tableId,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
-    @Operation(summary = "비교표 수정", description = "비교표 메타 데이터(제목)와 숙소 세부 내용, 비교 기준 정렬 순서, 숙소 정렬 순서를 수정합니다.")
+    @Operation(summary = "비교표 수정", description = "비교표 메타 데이터(제목)와 숙소 세부 내용, 비교 기준 정렬 순서, 숙소 정렬 순서를 수정합니다. (Authorization 헤더에 Bearer 토큰 필요)")
+    @SecurityRequirement(name = "JWT")
     ResponseEntity<StandardResponse<Boolean>> updateComparisonTable(
             @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "수정할 테이블의 ID") Long tableId,
             @RequestBody UpdateComparisonTableRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
-    @Operation(summary = "비교표 숙소 추가", description = "비교표에 새로운 숙소를 추가합니다.")
+    @Operation(summary = "비교표 숙소 추가", description = "비교표에 새로운 숙소를 추가합니다. (Authorization 헤더에 Bearer 토큰 필요)")
+    @SecurityRequirement(name = "JWT")
     ResponseEntity<StandardResponse<ComparisonTableResponse>> addAccommodationToComparisonTable(
             @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "테이블의 ID") Long tableId,
             @RequestBody AddAccommodationRequest request,

--- a/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
@@ -32,7 +32,7 @@ public interface OauthDocs {
             description = "카카오에서 발급받은 인가 코드를 통해 액세스 토큰을 획득하고, 사용자 정보를 조회하여 JWT 토큰을 헤더로 설정합니다. " +
                          "JWT 토큰은 응답 헤더로 전달되며, 응답 바디에는 사용자 정보만 포함됩니다. " +
                          "인가 코드와 baseUrl은 Query Parameter로 전달해야 합니다. " +
-                         "로그인 성공 후 응답 헤더의 ACCESS_TOKEN, 쿠키에 REFRESH_TOKEN이 전달됩니다."
+                         "로그인 성공 후 응답 헤더 ACCESS_TOKEN, 쿠키 REFRESH_TOKEN 로 각각 액세스 토큰, 리프레시 토큰이 전달됩니다."
     )
     @ApiResponse(
             responseCode = "200", 

--- a/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
@@ -32,7 +32,7 @@ public interface OauthDocs {
             description = "카카오에서 발급받은 인가 코드를 통해 액세스 토큰을 획득하고, 사용자 정보를 조회하여 JWT 토큰을 헤더로 설정합니다. " +
                          "JWT 토큰은 응답 헤더로 전달되며, 응답 바디에는 사용자 정보만 포함됩니다. " +
                          "인가 코드와 baseUrl은 Query Parameter로 전달해야 합니다. " +
-                         "로그인 성공 후 응답 헤더 ACCESS_TOKEN, 쿠키 REFRESH_TOKEN 로 각각 액세스 토큰, 리프레시 토큰이 전달됩니다."
+                         "로그인 성공 후 응답 헤더 access-token, 쿠키 REFRESH_TOKEN 로 각각 액세스 토큰, 리프레시 토큰이 전달됩니다."
     )
     @ApiResponse(
             responseCode = "200", 

--- a/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
@@ -32,7 +32,7 @@ public interface OauthDocs {
             description = "카카오에서 발급받은 인가 코드를 통해 액세스 토큰을 획득하고, 사용자 정보를 조회하여 JWT 토큰을 헤더로 설정합니다. " +
                          "JWT 토큰은 응답 헤더로 전달되며, 응답 바디에는 사용자 정보만 포함됩니다. " +
                          "인가 코드와 baseUrl은 Query Parameter로 전달해야 합니다. " +
-                         "로그인 성공 후 응답 헤더의 'Access-Token', 'Refresh-Token'에 토큰 정보가 전달됩니다."
+                         "로그인 성공 후 응답 헤더의 ACCESS_TOKEN, 쿠키에 REFRESH_TOKEN이 전달됩니다."
     )
     @ApiResponse(
             responseCode = "200", 

--- a/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
@@ -29,9 +29,10 @@ public interface OauthDocs {
 
     @Operation(
             summary = "카카오 OAuth 토큰 교환",
-            description = "카카오에서 발급받은 인가 코드를 통해 액세스 토큰을 획득하고, 사용자 정보를 조회하여 JWT 토큰을 쿠키로 설정합니다. " +
-                         "JWT 토큰은 HttpOnly 쿠키로 전달되며, 응답 바디에는 사용자 정보만 포함됩니다. " +
-                         "인가 코드와 baseUrl은 Query Parameter로 전달해야 합니다."
+            description = "카카오에서 발급받은 인가 코드를 통해 액세스 토큰을 획득하고, 사용자 정보를 조회하여 JWT 토큰을 헤더로 설정합니다. " +
+                         "JWT 토큰은 응답 헤더로 전달되며, 응답 바디에는 사용자 정보만 포함됩니다. " +
+                         "인가 코드와 baseUrl은 Query Parameter로 전달해야 합니다. " +
+                         "로그인 성공 후 응답 헤더의 'Access-Token', 'Refresh-Token'에 토큰 정보가 전달됩니다."
     )
     @ApiResponse(
             responseCode = "200", 

--- a/src/main/java/com/yapp/backend/controller/docs/TripBoardDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/TripBoardDocs.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
@@ -26,17 +27,20 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface TripBoardDocs {
 
         @Operation(summary = "여행 보드 생성", description = "새로운 여행 보드를 생성합니다. JWT 인증을 통해 현재 사용자 정보를 추출하고, 생성자는 자동으로 OWNER 역할로 등록되며 고유한 초대 링크가 생성됩니다.")
+        @SecurityRequirement(name = "JWT")
         ResponseEntity<StandardResponse<TripBoardCreateResponse>> createTripBoard(
                         @RequestBody @Valid TripBoardCreateRequest request,
                         @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
         @Operation(summary = "여행 보드 목록 조회", description = "사용자가 참여한 여행 보드 목록을 페이징으로 조회합니다. JWT 인증을 통해 현재 사용자 정보를 추출하고, 최신순으로 정렬된 결과를 반환합니다.")
+        @SecurityRequirement(name = "JWT")
         ResponseEntity<StandardResponse<TripBoardPageResponse>> getTripBoards(
                         @Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "페이지 번호") @NotNull(message = "페이지 번호는 필수입니다.") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.") Integer page,
                         @Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "페이지 크기") @NotNull(message = "페이지 크기는 필수입니다.") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") Integer size,
                         @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
         @Operation(summary = "여행 보드 수정", description = "기존 여행 보드의 기본 정보(보드 이름, 목적지, 여행 기간)를 수정합니다. JWT 인증을 통해 현재 사용자 정보를 추출하고, 수정된 보드 정보를 반환합니다.")
+        @SecurityRequirement(name = "JWT")
         ResponseEntity<StandardResponse<TripBoardUpdateResponse>> updateTripBoard(
                         @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "여행 보드 ID") @PathVariable Long tripBoardId,
                         @RequestBody @Valid TripBoardUpdateRequest request,

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -3,6 +3,7 @@ package com.yapp.backend.filter;
 import static com.yapp.backend.common.util.TokenUtil.extractTokenFromHeader;
 import static com.yapp.backend.common.util.CookieUtil.getCookieValue;
 
+import com.google.common.net.HttpHeaders;
 import com.yapp.backend.common.util.JwtTokenProvider;
 import com.yapp.backend.filter.service.AuthContextService;
 import com.yapp.backend.filter.service.RefreshTokenService;
@@ -29,6 +30,9 @@ public class JwtFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthContextService authContextService;
     private final RefreshTokenService refreshTokenService;
+
+    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN";
+    private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN";
 
     // 스킵할 URI(인증이 필요 없는 엔드포인트)
     @Override
@@ -61,7 +65,7 @@ public class JwtFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (JwtException | IllegalArgumentException bad) {
             // CASE 2: InValid Access Token - Refresh Token은 쿠키에서 추출 (보안상)
-            String refreshToken = getCookieValue(request, "REFRESH_TOKEN");
+            String refreshToken = getCookieValue(request, REFRESH_TOKEN_PREFIX);
             if (validateRefreshToken(refreshToken)) {
                 Long userId = Long.valueOf(jwtTokenProvider.getRefreshUsername(refreshToken));
                 updateAccessAndRefreshToken(response, userId);
@@ -100,9 +104,9 @@ public class JwtFilter extends OncePerRequestFilter {
         refreshTokenService.rotateRefresh(userId, newRefresh);
 
         // 3) 새로운 토큰 설정 (Access Token은 헤더, Refresh Token은 쿠키)
-        response.setHeader("ACCESS_TOKEN", newAccess);
+        response.setHeader(ACCESS_TOKEN_PREFIX, newAccess);
         ResponseCookie refreshCookie = jwtTokenProvider.generateRefreshTokenCookie(userId);
-        response.addHeader("Set-Cookie", refreshCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
         // 4) 인증 객체 세팅
         authContextService.createAuthContext(newAccess);

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -13,8 +13,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -102,7 +100,7 @@ public class JwtFilter extends OncePerRequestFilter {
         refreshTokenService.rotateRefresh(userId, newRefresh);
 
         // 3) 새로운 토큰 설정 (Access Token은 헤더, Refresh Token은 쿠키)
-        response.setHeader("Access-Token", newAccess);
+        response.setHeader("ACCESS_TOKEN", newAccess);
         ResponseCookie refreshCookie = jwtTokenProvider.generateRefreshTokenCookie(userId);
         response.addHeader("Set-Cookie", refreshCookie.toString());
 


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항

**1. Access Token 전달 방식 변경**
- **Before**: 쿠키 기반 토큰 전달
- **After**: HTTP 헤더 기반 토큰 전달 (`access-token` 헤더)

```
변경 이유
1. SPA 환경 호환성: 인증 헤더 방식이 SPA에서 더 유연하고 확장 가능
2. 크로스 플랫폼 지원: 추후 웹앱, 모바일 앱에서도 동일한 인증 방식 활용 가능
3. Swagger 문서화 편의성: 표준 Authorization 헤더 사용으로 자동 인식
4. 클라이언트 팀 선호도: 프론트엔드 개발자들의 선호 의견 반영
```

**2. Refresh token 쿠키 방식 유지**
-  보안상의 이유로 쿠키 세팅이 더 적합 -> 변경 x

**3. HTTP 헤더 네이밍 컨벤션 적용**
- Access Token: `access-token` (kebab-case)
- Refresh Token: `REFRESH_TOKEN` (UPPER_SNAKE_CASE)

**4. Swagger 문서화 개선**
- `@SecurityRequirement(name = "JWT")` 추가로 인증 필요 API 명시
- `@SecurityRequirements()` 추가로 인증 불필요 API 명시
- 표준 Bearer 토큰 스키마 사용으로 자동 인식

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항
@Torres-09 
- 숙소 카드 등록, 단건 조회 API 인증 필요없는 거 맞을까요?
- 기획상 필요할 것 같긴 한데, 아직 적용이 안되어 있는 건지 확인부탁드립니다 !

### 테스트 결과
<img width="710" height="377" alt="image" src="https://github.com/user-attachments/assets/e6d5a3b7-332f-4aa1-804b-b398b481ad57" />

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JWT 액세스 토큰이 이제 응답 헤더(ACCESS_TOKEN_HEADER)로 전달됩니다.
  * 리프레시 토큰은 기존과 같이 쿠키(REFRESH_TOKEN_COOKIE)로 전달됩니다.
  * API 문서(Swagger)에 JWT 인증 요구 사항이 명확히 표시됩니다.

* **Bug Fixes**
  * 토큰 추출 방식이 개선되어, 액세스 토큰을 Authorization 헤더에서 안전하게 추출합니다.

* **Documentation**
  * OAuth 및 기타 인증 관련 API 문서가 최신 토큰 전달 방식(헤더/쿠키)으로 업데이트되었습니다.
  * 인증이 필요한 엔드포인트에 JWT 보안 요구 사항이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->