### PR TITLE
[Y26W2-200] 여행보드 삭제 API 개발

### DIFF
--- a/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     INVALID_TRAVEL_PERIOD("유효하지 않은 여행 기간", "유효하지 않은 여행 기간입니다.", HttpStatus.BAD_REQUEST),
     TRIP_BOARD_NOT_FOUND("여행보드 존재하지 않음", "여행보드를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     TRIP_BOARD_UPDATE_FAILED("여행보드 수정 실패", "여행보드 수정에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    TRIP_BOARD_DELETE_FAILED("여행보드 삭제 실패", "여행보드 삭제 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // OAuth related errors
     INVALID_AUTHORIZATION_CODE("인가 코드 오류", "인가 코드가 유효하지 않거나 이미 사용되었습니다. 새로운 인가 코드를 발급받아 주세요.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/yapp/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yapp/backend/common/exception/GlobalExceptionHandler.java
@@ -129,6 +129,17 @@ public class GlobalExceptionHandler {
 				.body(new StandardResponse<>(ResponseType.ERROR, problemDetail));
 	}
 
+	@ExceptionHandler(TripBoardDeleteException.class)
+	public ResponseEntity<StandardResponse<ProblemDetail>> handleTripBoardDeleteException(
+			TripBoardDeleteException e) {
+		log.error("Trip board delete exception occurred: {}", e.getMessage(), e);
+		Sentry.captureException(e);
+		ErrorCode errorCode = e.getErrorCode();
+		ProblemDetail problemDetail = createProblemDetail(errorCode);
+		return ResponseEntity.status(errorCode.getHttpStatus())
+				.body(new StandardResponse<>(ResponseType.ERROR, problemDetail));
+	}
+
 	@ExceptionHandler(DuplicateInvitationUrlException.class)
 	public ResponseEntity<StandardResponse<ProblemDetail>> handleDuplicateInvitationUrlException(
 			DuplicateInvitationUrlException e) {

--- a/src/main/java/com/yapp/backend/common/exception/TripBoardDeleteException.java
+++ b/src/main/java/com/yapp/backend/common/exception/TripBoardDeleteException.java
@@ -1,0 +1,11 @@
+package com.yapp.backend.common.exception;
+
+/**
+ * 여행보드 삭제 중 오류가 발생했을 때 발생하는 예외
+ */
+public class TripBoardDeleteException extends CustomException {
+
+    public TripBoardDeleteException() {
+        super(ErrorCode.TRIP_BOARD_DELETE_FAILED);
+    }
+}

--- a/src/main/java/com/yapp/backend/controller/TripBoardController.java
+++ b/src/main/java/com/yapp/backend/controller/TripBoardController.java
@@ -55,10 +55,10 @@ public class TripBoardController implements TripBoardDocs {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         // JWT 인증을 통한 현재 사용자 정보 추출
-        Long userId = userDetails.getUserId();
+        Long whoAmI = userDetails.getUserId();
 
         // 여행 보드 생성
-        TripBoardCreateResponse response = tripBoardService.createTripBoard(request, userId);
+        TripBoardCreateResponse response = tripBoardService.createTripBoard(request, whoAmI);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new StandardResponse<>(ResponseType.SUCCESS, response));
@@ -75,14 +75,14 @@ public class TripBoardController implements TripBoardDocs {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         // JWT 인증을 통한 현재 사용자 정보 추출
-        Long userId = userDetails.getUserId();
+        Long whoAmI = userDetails.getUserId();
 
         // 페이징 객체 생성 (최신순 정렬: 생성일 내림차순)
         Pageable pageable = PageRequest.of(page, size,
                 Sort.by(Sort.Direction.DESC, "createdAt"));
 
         // 여행 보드 목록 조회
-        TripBoardPageResponse response = tripBoardService.getTripBoards(userId, pageable);
+        TripBoardPageResponse response = tripBoardService.getTripBoards(whoAmI, pageable);
 
         return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
     }
@@ -119,11 +119,13 @@ public class TripBoardController implements TripBoardDocs {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         // JWT 인증을 통한 현재 사용자 정보 추출
-        Long userId = userDetails.getUserId();
+        Long whoAmI = userDetails.getUserId();
 
-        // todo 비즈니스 로직안에서 여행보드 권한을 확인하는 데, 여행 보드 접근 권한 검증을 해야하는 지?
+        // 여행 보드 접근 권한 검증
+        authorizationService.validateTripBoardAccess(whoAmI, tripBoardId);
+
         // 여행 보드 삭제 (소유자 권한 검증 포함)
-        TripBoardDeleteResponse response = tripBoardService.deleteTripBoard(tripBoardId, userId);
+        TripBoardDeleteResponse response = tripBoardService.deleteTripBoard(tripBoardId, whoAmI);
 
         return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
     }

--- a/src/main/java/com/yapp/backend/controller/docs/TripBoardDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/TripBoardDocs.java
@@ -4,6 +4,7 @@ import com.yapp.backend.common.response.StandardResponse;
 import com.yapp.backend.controller.dto.request.TripBoardCreateRequest;
 import com.yapp.backend.controller.dto.request.TripBoardUpdateRequest;
 import com.yapp.backend.controller.dto.response.TripBoardCreateResponse;
+import com.yapp.backend.controller.dto.response.TripBoardDeleteResponse;
 import com.yapp.backend.controller.dto.response.TripBoardPageResponse;
 import com.yapp.backend.controller.dto.response.TripBoardUpdateResponse;
 import com.yapp.backend.filter.dto.CustomUserDetails;
@@ -44,5 +45,11 @@ public interface TripBoardDocs {
         ResponseEntity<StandardResponse<TripBoardUpdateResponse>> updateTripBoard(
                         @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "여행 보드 ID") @PathVariable Long tripBoardId,
                         @RequestBody @Valid TripBoardUpdateRequest request,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+
+        @Operation(summary = "여행 보드 삭제", description = "여행 보드와 관련된 모든 데이터를 삭제합니다. 오직 여행 보드의 소유자(OWNER)만이 삭제할 수 있으며, 삭제 시 해당 보드에 연관된 모든 리소스(숙소 정보, 멤버 매핑 관계, 비교표 등)가 함께 제거됩니다.")
+        @SecurityRequirement(name = "JWT")
+        ResponseEntity<StandardResponse<TripBoardDeleteResponse>> deleteTripBoard(
+                        @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "여행 보드 ID") @PathVariable Long tripBoardId,
                         @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/com/yapp/backend/controller/dto/response/TripBoardDeleteResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/TripBoardDeleteResponse.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/yapp/backend/controller/dto/response/TripBoardDeleteResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/TripBoardDeleteResponse.java
@@ -1,0 +1,16 @@
+package com.yapp.backend.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripBoardDeleteResponse {
+    private Long tripBoardId;
+}

--- a/src/main/java/com/yapp/backend/repository/AccommodationRepository.java
+++ b/src/main/java/com/yapp/backend/repository/AccommodationRepository.java
@@ -32,11 +32,17 @@ public interface AccommodationRepository {
 
     /**
      * 숙소 ID로 조회, 실패시 에러를 던집니다.
+     * 
      * @param accommodationId
      * @return
      */
     Accommodation findByIdOrThrow(Long accommodationId);
 
     void update(Accommodation updatedAccommodation);
+
+    /**
+     * 여행보드 ID로 해당 보드의 모든 숙소를 삭제합니다.
+     */
+    void deleteByBoardId(Long boardId);
 
 }

--- a/src/main/java/com/yapp/backend/repository/ComparisonTableRepository.java
+++ b/src/main/java/com/yapp/backend/repository/ComparisonTableRepository.java
@@ -6,11 +6,16 @@ public interface ComparisonTableRepository {
     Long save(ComparisonTable comparisonTable);
 
     ComparisonTable findByIdOrThrow(Long tableId);
-    
+
     void update(ComparisonTable comparisonTable);
-    
+
     /**
      * 비교표에 새로운 숙소들을 추가합니다 (매핑 테이블에만 추가)
      */
     ComparisonTable addAccommodationsToTable(Long tableId, java.util.List<Long> accommodationIds, Long userId);
-} 
+
+    /**
+     * 여행보드 ID로 해당 보드의 모든 비교표를 삭제합니다.
+     */
+    void deleteByTripBoardId(Long tripBoardId);
+}

--- a/src/main/java/com/yapp/backend/repository/JpaAccommodationRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaAccommodationRepository.java
@@ -55,4 +55,9 @@ public interface JpaAccommodationRepository extends JpaRepository<AccommodationE
         @Query("SELECT a FROM AccommodationEntity a WHERE a.boardId = :boardId AND a.createdBy.id = :userId ORDER BY a.lowestPrice ASC")
         Page<AccommodationEntity> findByBoardIdAndCreatedByOrderByLowestPriceAsc(@Param("boardId") Long boardId,
                         @Param("userId") Long userId, Pageable pageable);
+
+        /**
+         * 여행보드 ID로 해당 보드의 모든 숙소를 삭제합니다.
+         */
+        void deleteByBoardId(Long boardId);
 }

--- a/src/main/java/com/yapp/backend/repository/JpaComparisonTableRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaComparisonTableRepository.java
@@ -8,5 +8,5 @@ public interface JpaComparisonTableRepository extends JpaRepository<ComparisonTa
     /**
      * 여행보드 ID로 해당 보드의 모든 비교표를 삭제합니다.
      */
-    void deleteByTripBoardId(Long tripBoardId);
+    void deleteByTripBoardEntityId(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/JpaComparisonTableRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaComparisonTableRepository.java
@@ -4,4 +4,9 @@ import com.yapp.backend.repository.entity.ComparisonTableEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaComparisonTableRepository extends JpaRepository<ComparisonTableEntity, Long> {
-} 
+
+    /**
+     * 여행보드 ID로 해당 보드의 모든 비교표를 삭제합니다.
+     */
+    void deleteByTripBoardId(Long tripBoardId);
+}

--- a/src/main/java/com/yapp/backend/repository/JpaTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaTripBoardRepository.java
@@ -2,8 +2,19 @@ package com.yapp.backend.repository;
 
 import com.yapp.backend.repository.entity.TripBoardEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface JpaTripBoardRepository extends JpaRepository<TripBoardEntity, Long> {
+
+    /**
+     * 여행 보드 ID와 생성자 ID로 여행 보드를 조회합니다. (소유자 검증용)
+     */
+    @Query("SELECT tb FROM TripBoardEntity tb WHERE tb.id = :tripBoardId AND tb.createdBy.id = :createdById")
+    Optional<TripBoardEntity> findByIdAndCreatedById(@Param("tripBoardId") Long tripBoardId,
+            @Param("createdById") Long createdById);
 }

--- a/src/main/java/com/yapp/backend/repository/JpaUserTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaUserTripBoardRepository.java
@@ -57,4 +57,9 @@ public interface JpaUserTripBoardRepository extends JpaRepository<UserTripBoardE
                         "JOIN FETCH utb.user u " +
                         "WHERE utb.tripBoard.id IN :tripBoardIds")
         List<UserTripBoardEntity> findByTripBoardIdsWithUser(@Param("tripBoardIds") List<Long> tripBoardIds);
+
+        /**
+         * 여행보드 ID로 해당 보드의 모든 사용자 매핑을 삭제합니다.
+         */
+        void deleteByTripBoardId(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/TripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/TripBoardRepository.java
@@ -40,4 +40,14 @@ public interface TripBoardRepository {
      * 여행 보드를 업데이트합니다.
      */
     TripBoard updateTripBoard(TripBoard tripBoard);
+
+    /**
+     * ID로 여행 보드를 삭제합니다.
+     */
+    void deleteById(Long id);
+
+    /**
+     * 여행 보드 ID와 생성자 ID로 여행 보드를 조회합니다. (소유자 검증용)
+     */
+    Optional<TripBoard> findByIdAndCreatedById(Long tripBoardId, Long createdById);
 }

--- a/src/main/java/com/yapp/backend/repository/UserTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/UserTripBoardRepository.java
@@ -1,0 +1,12 @@
+package com.yapp.backend.repository;
+
+/**
+ * 사용자-여행보드 매핑 Repository 인터페이스
+ */
+public interface UserTripBoardRepository {
+
+    /**
+     * 여행보드 ID로 해당 보드의 모든 사용자 매핑을 삭제합니다.
+     */
+    void deleteByTripBoardId(Long tripBoardId);
+}

--- a/src/main/java/com/yapp/backend/repository/impl/AccommodationRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/AccommodationRepositoryImpl.java
@@ -22,101 +22,105 @@ import java.util.stream.Collectors;
 @Repository
 @RequiredArgsConstructor
 public class AccommodationRepositoryImpl implements AccommodationRepository {
-	private final JpaAccommodationRepository jpaAccommodationRepository;
-	private final AccommodationMapper accommodationMapper;
+    private final JpaAccommodationRepository jpaAccommodationRepository;
+    private final AccommodationMapper accommodationMapper;
 
-	/**
-	 * 여행보드 ID로 숙소 목록을 페이징하여 조회하는 쿼리
-	 * userId가 null이 아닌 경우 해당 사용자가 생성한 숙소만 조회
-	 * sort 파라미터에 따라 정렬 방식 결정 (saved_at_desc: 최근 등록순, price_asc: 가격 낮은 순)
-	 */
-	@Override
-	public List<Accommodation> findByBoardIdWithPagination(Long boardId, int page, int size, Long userId, String sort) {
-		Pageable pageable = PageRequest.of(page, size);
-		Page<AccommodationEntity> entityPage;
+    /**
+     * 여행보드 ID로 숙소 목록을 페이징하여 조회하는 쿼리
+     * userId가 null이 아닌 경우 해당 사용자가 생성한 숙소만 조회
+     * sort 파라미터에 따라 정렬 방식 결정 (saved_at_desc: 최근 등록순, price_asc: 가격 낮은 순)
+     */
+    @Override
+    public List<Accommodation> findByBoardIdWithPagination(Long boardId, int page, int size, Long userId, String sort) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<AccommodationEntity> entityPage;
 
-		// 정렬 방식에 따른 쿼리 선택
-		SortType sortType = SortType.fromString(sort);
-		boolean isPriceSort = sortType == SortType.PRICE_ASC;
+        // 정렬 방식에 따른 쿼리 선택
+        SortType sortType = SortType.fromString(sort);
+        boolean isPriceSort = sortType == SortType.PRICE_ASC;
 
-		entityPage = userId != null
-			? getEntityPageWithUserId(boardId, userId, pageable, isPriceSort)
-			: getEntityPageWithoutUserId(boardId, pageable, isPriceSort);
+        entityPage = userId != null
+                ? getEntityPageWithUserId(boardId, userId, pageable, isPriceSort)
+                : getEntityPageWithoutUserId(boardId, pageable, isPriceSort);
 
-		return entityPage.getContent().stream()
-			.map(this::convertToAccommodation)
-			.collect(Collectors.toList());
-	}
+        return entityPage.getContent().stream()
+                .map(this::convertToAccommodation)
+                .collect(Collectors.toList());
+    }
 
-	/**
-	 * 테이블 ID로 숙소 개수를 조회
-	 * userId가 null이 아닌 경우 해당 사용자가 생성한 숙소 개수만 조회
-	 */
-	@Override
-	public Long countByBoardId(Long boardId, Long userId) {
-		if (userId != null) {
-			return jpaAccommodationRepository.countByBoardIdAndCreatedBy(boardId, userId);
-		} else {
-			return jpaAccommodationRepository.countByBoardId(boardId);
-		}
-	}
+    /**
+     * 테이블 ID로 숙소 개수를 조회
+     * userId가 null이 아닌 경우 해당 사용자가 생성한 숙소 개수만 조회
+     */
+    @Override
+    public Long countByBoardId(Long boardId, Long userId) {
+        if (userId != null) {
+            return jpaAccommodationRepository.countByBoardIdAndCreatedBy(boardId, userId);
+        } else {
+            return jpaAccommodationRepository.countByBoardId(boardId);
+        }
+    }
 
-	/**
-	 * 숙소를 저장합니다.
-	 */
-	@Override
-	public Accommodation save(AccommodationEntity accommodationEntity) {
-		AccommodationEntity savedEntity = jpaAccommodationRepository.save(accommodationEntity);
-		return convertToAccommodation(savedEntity);
-	}
+    /**
+     * 숙소를 저장합니다.
+     */
+    @Override
+    public Accommodation save(AccommodationEntity accommodationEntity) {
+        AccommodationEntity savedEntity = jpaAccommodationRepository.save(accommodationEntity);
+        return convertToAccommodation(savedEntity);
+    }
 
-	@Override
-	public Accommodation findByIdOrThrow(Long accommodationId) {
-		AccommodationEntity accommodationEntity = jpaAccommodationRepository.findById(accommodationId)
-				.orElseThrow(() -> new AccommodationNotFoundException(ErrorCode.ACCOMMODATION_NOT_FOUND));
-		return accommodationMapper.entityToDomain(accommodationEntity);
-	}
+    @Override
+    public Accommodation findByIdOrThrow(Long accommodationId) {
+        AccommodationEntity accommodationEntity = jpaAccommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new AccommodationNotFoundException(ErrorCode.ACCOMMODATION_NOT_FOUND));
+        return accommodationMapper.entityToDomain(accommodationEntity);
+    }
 
+    /**
+     * 숙소 ID로 단건 조회합니다.
+     */
+    @Override
+    public Accommodation findById(Long accommodationId) {
+        AccommodationEntity entity = jpaAccommodationRepository.findByAccommodationId(accommodationId);
+        return entity != null ? convertToAccommodation(entity) : null;
+    }
 
-	/**
-	 * 숙소 ID로 단건 조회합니다.
-	 */
-	@Override
-	public Accommodation findById(Long accommodationId) {
-		AccommodationEntity entity = jpaAccommodationRepository.findByAccommodationId(accommodationId);
-		return entity != null ? convertToAccommodation(entity) : null;
-	}
+    /**
+     * userId가 있는 경우의 엔티티 페이지 조회
+     */
+    private Page<AccommodationEntity> getEntityPageWithUserId(Long boardId, Long userId, Pageable pageable,
+                                                              boolean isPriceSort) {
+        return isPriceSort
+                ? jpaAccommodationRepository.findByBoardIdAndCreatedByOrderByLowestPriceAsc(boardId, userId, pageable)
+                : jpaAccommodationRepository.findByBoardIdAndCreatedByOrderByCreatedAtDesc(boardId, userId, pageable);
+    }
 
-	/**
-	 * userId가 있는 경우의 엔티티 페이지 조회
-	 */
-	private Page<AccommodationEntity> getEntityPageWithUserId(Long boardId, Long userId, Pageable pageable,
-		boolean isPriceSort) {
-		return isPriceSort
-			? jpaAccommodationRepository.findByBoardIdAndCreatedByOrderByLowestPriceAsc(boardId, userId, pageable)
-			: jpaAccommodationRepository.findByBoardIdAndCreatedByOrderByCreatedAtDesc(boardId, userId, pageable);
-	}
+    /**
+     * userId가 없는 경우의 엔티티 페이지 조회
+     */
+    private Page<AccommodationEntity> getEntityPageWithoutUserId(Long boardId, Pageable pageable, boolean isPriceSort) {
+        return isPriceSort
+                ? jpaAccommodationRepository.findByBoardIdOrderByLowestPriceAsc(boardId, pageable)
+                : jpaAccommodationRepository.findByBoardIdOrderByCreatedAtDesc(boardId, pageable);
+    }
 
-	/**
-	 * userId가 없는 경우의 엔티티 페이지 조회
-	 */
-	private Page<AccommodationEntity> getEntityPageWithoutUserId(Long boardId, Pageable pageable, boolean isPriceSort) {
-		return isPriceSort
-			? jpaAccommodationRepository.findByBoardIdOrderByLowestPriceAsc(boardId, pageable)
-			: jpaAccommodationRepository.findByBoardIdOrderByCreatedAtDesc(boardId, pageable);
-	}
+    /**
+     * Convert AccommodationEntity to Accommodation domain model
+     */
+    private Accommodation convertToAccommodation(AccommodationEntity entity) {
+        return accommodationMapper.entityToDomain(entity);
+    }
 
-	/**
-	 * Convert AccommodationEntity to Accommodation domain model
-	 */
-	private Accommodation convertToAccommodation(AccommodationEntity entity) {
-		return accommodationMapper.entityToDomain(entity);
-	}
+    @Override
+    public void update(Accommodation updatedAccommodation) {
+        AccommodationEntity accommodationEntity = accommodationMapper.domainToEntity(updatedAccommodation);
+        jpaAccommodationRepository.save(accommodationEntity);
+    }
 
-	@Override
-	public void update(Accommodation updatedAccommodation) {
-		AccommodationEntity accommodationEntity = accommodationMapper.domainToEntity(updatedAccommodation);
-		jpaAccommodationRepository.save(accommodationEntity);
-	}
+    @Override
+    public void deleteByBoardId(Long boardId) {
+        jpaAccommodationRepository.deleteByBoardId(boardId);
+    }
 
 }

--- a/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
@@ -152,4 +152,9 @@ public class ComparisonTableRepositoryImpl implements ComparisonTableRepository 
         jpaComparisonTableRepository.save(tableEntity);
         return comparisonTableMapper.entityToDomain(tableEntity);
     }
+
+    @Override
+    public void deleteByTripBoardId(Long tripBoardId) {
+        jpaComparisonTableRepository.deleteByTripBoardId(tripBoardId);
+    }
 }

--- a/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
@@ -155,6 +155,6 @@ public class ComparisonTableRepositoryImpl implements ComparisonTableRepository 
 
     @Override
     public void deleteByTripBoardId(Long tripBoardId) {
-        jpaComparisonTableRepository.deleteByTripBoardId(tripBoardId);
+        jpaComparisonTableRepository.deleteByTripBoardEntityId(tripBoardId);
     }
 }

--- a/src/main/java/com/yapp/backend/repository/impl/TripBoardRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/TripBoardRepositoryImpl.java
@@ -96,4 +96,15 @@ public class TripBoardRepositoryImpl implements TripBoardRepository {
         return tripBoardMapper.entityToDomain(updatedEntity);
     }
 
+    @Override
+    public void deleteById(Long id) {
+        jpaTripBoardRepository.deleteById(id);
+    }
+
+    @Override
+    public Optional<TripBoard> findByIdAndCreatedById(Long tripBoardId, Long createdById) {
+        return jpaTripBoardRepository.findByIdAndCreatedById(tripBoardId, createdById)
+                .map(tripBoardMapper::entityToDomain);
+    }
+
 }

--- a/src/main/java/com/yapp/backend/repository/impl/UserTripBoardRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/UserTripBoardRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.yapp.backend.repository.impl;
+
+import com.yapp.backend.repository.JpaUserTripBoardRepository;
+import com.yapp.backend.repository.UserTripBoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 사용자-여행보드 매핑 Repository 구현체
+ */
+@Repository
+@RequiredArgsConstructor
+public class UserTripBoardRepositoryImpl implements UserTripBoardRepository {
+
+    private final JpaUserTripBoardRepository jpaUserTripBoardRepository;
+
+    @Override
+    public void deleteByTripBoardId(Long tripBoardId) {
+        jpaUserTripBoardRepository.deleteByTripBoardId(tripBoardId);
+    }
+}

--- a/src/main/java/com/yapp/backend/service/TripBoardService.java
+++ b/src/main/java/com/yapp/backend/service/TripBoardService.java
@@ -3,6 +3,7 @@ package com.yapp.backend.service;
 import com.yapp.backend.controller.dto.request.TripBoardCreateRequest;
 import com.yapp.backend.controller.dto.request.TripBoardUpdateRequest;
 import com.yapp.backend.controller.dto.response.TripBoardCreateResponse;
+import com.yapp.backend.controller.dto.response.TripBoardDeleteResponse;
 import com.yapp.backend.controller.dto.response.TripBoardPageResponse;
 import com.yapp.backend.controller.dto.response.TripBoardUpdateResponse;
 import org.springframework.data.domain.Pageable;
@@ -13,4 +14,6 @@ public interface TripBoardService {
     TripBoardPageResponse getTripBoards(Long userId, Pageable pageable);
 
     TripBoardUpdateResponse updateTripBoard(Long tripBoardId, TripBoardUpdateRequest request, Long userId);
+
+    TripBoardDeleteResponse deleteTripBoard(Long tripBoardId, Long userId);
 }

--- a/src/main/java/com/yapp/backend/service/impl/TripBoardServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/TripBoardServiceImpl.java
@@ -4,23 +4,29 @@ import com.yapp.backend.common.exception.InvalidDestinationException;
 import com.yapp.backend.common.exception.InvalidPagingParameterException;
 import com.yapp.backend.common.exception.InvalidTravelPeriodException;
 import com.yapp.backend.common.exception.TripBoardCreationException;
+import com.yapp.backend.common.exception.TripBoardDeleteException;
 import com.yapp.backend.common.exception.TripBoardNotFoundException;
 import com.yapp.backend.common.exception.TripBoardParticipantLimitExceededException;
 import com.yapp.backend.common.exception.TripBoardUpdateException;
+import com.yapp.backend.common.exception.UserAuthorizationException;
 import com.yapp.backend.common.util.InvitationLinkGeneratorUtil;
 import com.yapp.backend.common.util.PageUtil;
 import com.yapp.backend.controller.dto.request.TripBoardCreateRequest;
 import com.yapp.backend.controller.dto.request.TripBoardUpdateRequest;
 import com.yapp.backend.controller.dto.response.TripBoardCreateResponse;
+import com.yapp.backend.controller.dto.response.TripBoardDeleteResponse;
 import com.yapp.backend.controller.dto.response.TripBoardPageResponse;
 import com.yapp.backend.controller.dto.response.TripBoardSummaryResponse;
 import com.yapp.backend.controller.dto.response.TripBoardUpdateResponse;
 import com.yapp.backend.controller.mapper.TripBoardSummaryMapper;
 import com.yapp.backend.controller.mapper.TripBoardUpdateMapper;
+import com.yapp.backend.repository.AccommodationRepository;
+import com.yapp.backend.repository.ComparisonTableRepository;
 import com.yapp.backend.repository.JpaTripBoardRepository;
 import com.yapp.backend.repository.JpaUserTripBoardRepository;
 import com.yapp.backend.repository.TripBoardRepository;
 import com.yapp.backend.repository.UserRepository;
+import com.yapp.backend.repository.UserTripBoardRepository;
 import com.yapp.backend.repository.entity.TripBoardEntity;
 import com.yapp.backend.repository.entity.UserEntity;
 import com.yapp.backend.repository.entity.UserTripBoardEntity;
@@ -57,9 +63,12 @@ public class TripBoardServiceImpl implements TripBoardService {
     private static final int MAX_PARTICIPANTS = 10;
 
     private final JpaTripBoardRepository jpaTripBoardRepository;
-    private final JpaUserTripBoardRepository userTripBoardRepository;
+    private final JpaUserTripBoardRepository jpaUserTripBoardRepository;
     private final TripBoardRepository tripBoardRepository;
     private final UserRepository userRepository;
+    private final AccommodationRepository accommodationRepository;
+    private final ComparisonTableRepository comparisonTableRepository;
+    private final UserTripBoardRepository userTripBoardRepository;
 
     private final UserMapper userMapper;
     private final TripBoardMapper tripBoardMapper;
@@ -113,7 +122,7 @@ public class TripBoardServiceImpl implements TripBoardService {
                     .role(TripBoardRole.OWNER)
                     .build();
 
-            UserTripBoardEntity savedUserTripBoard = userTripBoardRepository.save(userTripBoardEntity);
+            UserTripBoardEntity savedUserTripBoard = jpaUserTripBoardRepository.save(userTripBoardEntity);
             log.debug("사용자-여행보드 매핑 저장 완료 - ID: {}", savedUserTripBoard.getId());
 
             // 7. Entity를 Domain Model로 변환
@@ -263,6 +272,94 @@ public class TripBoardServiceImpl implements TripBoardService {
         } catch (Exception e) {
             log.error("여행 보드 수정 중 예상치 못한 오류 발생 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId, e);
             throw new TripBoardUpdateException();
+        }
+    }
+
+    /**
+     * 여행 보드 삭제
+     * 소유자만 삭제할 수 있으며, 관련된 모든 데이터를 cascade 방식으로 삭제합니다.
+     */
+    @Override
+    @Transactional
+    public TripBoardDeleteResponse deleteTripBoard(Long tripBoardId, Long userId) {
+        try {
+            log.info("여행 보드 삭제 시작 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId);
+
+            // 1. 여행보드 존재 여부 및 소유자 권한 검증
+            TripBoard tripBoard = validateOwnershipAndGetTripBoard(tripBoardId, userId);
+
+            // 2. 관련 데이터 cascade 삭제 (순서 중요)
+            deleteRelatedData(tripBoardId);
+
+            // 3. 여행보드 삭제
+            tripBoardRepository.deleteById(tripBoardId);
+            log.debug("여행 보드 삭제 완료 - 보드 ID: {}", tripBoardId);
+
+            // 4. 응답 생성
+            TripBoardDeleteResponse response = TripBoardDeleteResponse.builder()
+                    .tripBoardId(tripBoardId)
+                    .build();
+
+            log.info("여행 보드 삭제 완료 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId);
+            return response;
+
+        } catch (TripBoardNotFoundException | UserAuthorizationException e) {
+            log.error("여행 보드 삭제 실패 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId, e);
+            throw e;
+        } catch (DataAccessException e) {
+            log.error("여행 보드 삭제 중 데이터베이스 오류 발생 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId, e);
+            throw new TripBoardDeleteException();
+        } catch (Exception e) {
+            log.error("여행 보드 삭제 중 예상치 못한 오류 발생 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId, e);
+            throw new TripBoardDeleteException();
+        }
+    }
+
+    /**
+     * 여행보드 소유자 권한 검증 및 여행보드 조회
+     */
+    private TripBoard validateOwnershipAndGetTripBoard(Long tripBoardId, Long userId) {
+        // 여행보드 존재 여부 확인
+        TripBoard tripBoard = tripBoardRepository.findById(tripBoardId)
+                .orElseThrow(() -> {
+                    log.warn("존재하지 않는 여행보드 삭제 시도 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId);
+                    return new TripBoardNotFoundException();
+                });
+
+        // 소유자 권한 검증 (createdBy 필드와 사용자 ID 비교)
+        if (!tripBoard.getCreatedBy().getId().equals(userId)) {
+            log.warn("권한 없는 사용자의 여행보드 삭제 시도 - 보드 ID: {}, 요청 사용자 ID: {}, 소유자 ID: {}",
+                    tripBoardId, userId, tripBoard.getCreatedBy().getId());
+            throw new UserAuthorizationException(userId, tripBoardId);
+        }
+
+        return tripBoard;
+    }
+
+    /**
+     * 여행보드와 관련된 모든 데이터를 순서에 따라 삭제
+     * 삭제 순서: ComparisonAccommodation → ComparisonTable → Accommodation →
+     * UserTripBoard
+     */
+    private void deleteRelatedData(Long tripBoardId) {
+        log.debug("관련 데이터 삭제 시작 - 보드 ID: {}", tripBoardId);
+
+        try {
+            // 1. 비교표 삭제 (ComparisonAccommodation 매핑도 함께 삭제됨)
+            comparisonTableRepository.deleteByTripBoardId(tripBoardId);
+            log.debug("비교표 삭제 완료 - 보드 ID: {}", tripBoardId);
+
+            // 2. 숙소 삭제
+            accommodationRepository.deleteByBoardId(tripBoardId);
+            log.debug("숙소 삭제 완료 - 보드 ID: {}", tripBoardId);
+
+            // 3. 사용자-여행보드 매핑 삭제
+            userTripBoardRepository.deleteByTripBoardId(tripBoardId);
+            log.debug("사용자-여행보드 매핑 삭제 완료 - 보드 ID: {}", tripBoardId);
+
+        } catch (Exception e) {
+            log.error("관련 데이터 삭제 중 오류 발생 - 보드 ID: {}", tripBoardId, e);
+            throw e;
         }
     }
 

--- a/src/main/java/com/yapp/backend/service/impl/TripBoardServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/TripBoardServiceImpl.java
@@ -286,7 +286,7 @@ public class TripBoardServiceImpl implements TripBoardService {
             log.info("여행 보드 삭제 시작 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId);
 
             // 1. 여행보드 존재 여부 및 소유자 권한 검증
-            TripBoard tripBoard = validateOwnershipAndGetTripBoard(tripBoardId, userId);
+            validateOwnershipAndGetTripBoard(tripBoardId, userId);
 
             // 2. 관련 데이터 cascade 삭제 (순서 중요)
             deleteRelatedData(tripBoardId);
@@ -318,7 +318,7 @@ public class TripBoardServiceImpl implements TripBoardService {
     /**
      * 여행보드 소유자 권한 검증 및 여행보드 조회
      */
-    private TripBoard validateOwnershipAndGetTripBoard(Long tripBoardId, Long userId) {
+    private void validateOwnershipAndGetTripBoard(Long tripBoardId, Long userId) {
         // 여행보드 존재 여부 확인
         TripBoard tripBoard = tripBoardRepository.findById(tripBoardId)
                 .orElseThrow(() -> {
@@ -332,8 +332,6 @@ public class TripBoardServiceImpl implements TripBoardService {
                     tripBoardId, userId, tripBoard.getCreatedBy().getId());
             throw new UserAuthorizationException(userId, tripBoardId);
         }
-
-        return tripBoard;
     }
 
     /**

--- a/src/main/java/com/yapp/backend/service/impl/UserTripBoardAuthorizationServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/UserTripBoardAuthorizationServiceImpl.java
@@ -34,7 +34,6 @@ public class UserTripBoardAuthorizationServiceImpl implements UserTripBoardAutho
 
             log.info("여행보드 접근 권한 검증 통과 - 사용자 ID: {}, 보드 ID: {}", userId, boardId);
         } catch (UserAuthorizationException e) {
-            // 이미 로깅된 예외를 다시 던짐
             throw e;
         } catch (Exception e) {
             log.error("여행보드 접근 권한 검증 중 예외 발생 - 사용자 ID: {}, 보드 ID: {}, 오류: {}",


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
여행 보드 삭제 API 추가
OWNER만 삭제 가능

### PR 체크리스트
- [X] 정상적으로 실행이 되나요?
- [X] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [X] 컨벤션 규칙을 지켰나요?
- [X] merge branch 를 확인했나요?


### 추가 전달 사항
- // todo 비즈니스 로직안에서 여행보드 권한을 확인하는 데, 여행 보드 접근 권한 검증을 해야하는 지? 
위의 내용이 고민입니다~!..!

### 테스트 결과
<img width="1089" height="431" alt="image" src="https://github.com/user-attachments/assets/ebc1f10f-2676-4e93-ad53-41ed486d96b3" />

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 여행 보드 삭제 기능이 추가되었습니다. 사용자는 본인이 소유한 여행 보드를 삭제할 수 있으며, 삭제 시 관련 숙소, 멤버 매핑, 비교표 등 모든 연관 데이터가 함께 제거됩니다.

* **문서화**
  * 여행 보드 삭제 API에 대한 설명과 보안 요구사항이 추가되었습니다.

* **기타**
  * 삭제 실패 시 표준화된 에러 메시지와 응답이 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->