### PR TITLE
[Y26W2-210] 사용자 로그아웃 기능

### DIFF
--- a/src/main/java/com/yapp/backend/common/util/CookieUtil.java
+++ b/src/main/java/com/yapp/backend/common/util/CookieUtil.java
@@ -4,10 +4,16 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class CookieUtil {
-
+    
+    @Value("${cookie.secure:false}")
+    private boolean cookieSecure;
+    
     public static final String REFRESH_TOKEN_COOKIE = "REFRESH_TOKEN";
 
     /**
@@ -33,14 +39,13 @@ public class CookieUtil {
      * @param cookieName 무효화할 쿠키 이름
      * @return 무효화된 ResponseCookie
      */
-    public static ResponseCookie createInvalidatedCookie(String cookieName) {
+    public ResponseCookie createInvalidatedCookie(String cookieName) {
         return ResponseCookie.from(cookieName, "")
                 .path("/")
                 .maxAge(0) // 즉시 만료
                 .httpOnly(true)
-                .secure(false) // 개발환경용, 프로덕션에서는 true로 설정
+                .secure(cookieSecure) // YAML 설정값 사용
                 .sameSite("Lax")
                 .build();
     }
-
 }

--- a/src/main/java/com/yapp/backend/common/util/CookieUtil.java
+++ b/src/main/java/com/yapp/backend/common/util/CookieUtil.java
@@ -2,10 +2,14 @@ package com.yapp.backend.common.util;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CookieUtil {
+
+    public static final String REFRESH_TOKEN_COOKIE = "REFRESH_TOKEN";
+
     /**
      * HttpServletRequest 에서 이름이 cookieName 인 쿠키 값을 꺼내 반환.
      * 없으면 null.
@@ -23,5 +27,20 @@ public class CookieUtil {
         return null;
     }
 
+    /**
+     * 쿠키를 무효화하는 ResponseCookie를 생성합니다.
+     * 
+     * @param cookieName 무효화할 쿠키 이름
+     * @return 무효화된 ResponseCookie
+     */
+    public static ResponseCookie createInvalidatedCookie(String cookieName) {
+        return ResponseCookie.from(cookieName, "")
+                .path("/")
+                .maxAge(0) // 즉시 만료
+                .httpOnly(true)
+                .secure(false) // 개발환경용, 프로덕션에서는 true로 설정
+                .sameSite("Lax")
+                .build();
+    }
 
 }

--- a/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
@@ -2,6 +2,7 @@ package com.yapp.backend.controller.docs;
 
 import com.yapp.backend.common.response.StandardResponse;
 import com.yapp.backend.controller.dto.response.AuthorizeUrlResponse;
+import com.yapp.backend.controller.dto.response.LogoutResponse;
 import com.yapp.backend.controller.dto.response.OauthLoginResponse;
 import com.yapp.backend.filter.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -60,7 +61,7 @@ public interface OauthDocs {
             description = "로그아웃이 성공적으로 완료되었습니다."
     )
     @SecurityRequirement(name = "JWT")
-    ResponseEntity<StandardResponse<Boolean>> logout(
+    ResponseEntity<StandardResponse<LogoutResponse>> logout(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(hidden = true) HttpServletRequest request,
             @Parameter(hidden = true) HttpServletResponse response

--- a/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
@@ -3,12 +3,16 @@ package com.yapp.backend.controller.docs;
 import com.yapp.backend.common.response.StandardResponse;
 import com.yapp.backend.controller.dto.response.AuthorizeUrlResponse;
 import com.yapp.backend.controller.dto.response.OauthLoginResponse;
+import com.yapp.backend.filter.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "OAUTH API", description = "소셜 로그인 API")
@@ -41,6 +45,24 @@ public interface OauthDocs {
     ResponseEntity<StandardResponse<OauthLoginResponse>> exchangeKakaoToken(
             @RequestParam("code") String code,
             @RequestParam("baseUrl") String baseUrl,
+            @Parameter(hidden = true) HttpServletResponse response
+    );
+
+    @Operation(
+            summary = "사용자 로그아웃",
+            description = "현재 로그인된 사용자의 세션을 종료합니다. " +
+                         "헤더에 있는 access-token 토큰을 블랙리스트에 추가합니다. " +
+                         "Redis에서 Refresh Token을 삭제하고 브라우저의 REFRESH_TOKEN 쿠키를 무효화합니다. " +
+                         "로그아웃 후에는 새로운 인증이 필요합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그아웃이 성공적으로 완료되었습니다."
+    )
+    @SecurityRequirement(name = "JWT")
+    ResponseEntity<StandardResponse<Boolean>> logout(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(hidden = true) HttpServletRequest request,
             @Parameter(hidden = true) HttpServletResponse response
     );
 

--- a/src/main/java/com/yapp/backend/controller/dto/response/AuthorizeUrlResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/AuthorizeUrlResponse.java
@@ -1,9 +1,13 @@
 package com.yapp.backend.controller.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
+@AllArgsConstructor
 @Schema(description = "OAuth 인가 URL 응답")
-public record AuthorizeUrlResponse(
+public class AuthorizeUrlResponse {
         @Schema(description = "카카오 OAuth 인가 URL", example = "https://kauth.kakao.com/oauth/authorize?client_id=...")
-        String authorizeUrl
-) {}
+        private String authorizeUrl;
+}

--- a/src/main/java/com/yapp/backend/controller/dto/response/LogoutResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/LogoutResponse.java
@@ -1,0 +1,10 @@
+package com.yapp.backend.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LogoutResponse {
+    private boolean isLogout;
+}

--- a/src/main/java/com/yapp/backend/controller/dto/response/OauthLoginResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/OauthLoginResponse.java
@@ -1,12 +1,13 @@
 package com.yapp.backend.controller.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
+@AllArgsConstructor
 @Schema(description = "OAuth 로그인 응답")
-public record OauthLoginResponse(
-        @Schema(description = "사용자 ID")
-        Long userId,
-        
-        @Schema(description = "사용자 닉네임")
-        String nickname
-) {}
+public class OauthLoginResponse {
+        private Long userId;
+        private String nickname;
+}

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -62,6 +62,13 @@ public class JwtFilter extends OncePerRequestFilter {
         try {
             // CASE 1: Valid Access Token
             jwtTokenProvider.validateAccessTokenOrThrow(accessToken);
+            
+            // 블랙리스트 확인
+            if (refreshTokenService.isAccessTokenBlacklisted(accessToken)) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token is blacklisted");
+                return;
+            }
+            
             authContextService.createAuthContext(accessToken);
             filterChain.doFilter(request, response);
         } catch (JwtException | IllegalArgumentException bad) {

--- a/src/main/java/com/yapp/backend/filter/service/RefreshTokenService.java
+++ b/src/main/java/com/yapp/backend/filter/service/RefreshTokenService.java
@@ -2,22 +2,33 @@ package com.yapp.backend.filter.service;
 
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
 
     private static final String REFRESH_TOKEN_PREFIX = "refresh_token ";
+    private static final String ACCESS_TOKEN_BLACKLIST_PREFIX = "access_token_blacklist ";
+    
     @Value("${spring.security.jwt.refresh-token-validity-in-ms}")
     private long refreshTtlMs;
+    
+    @Value("${spring.security.jwt.access-token-validity-in-ms}")
+    private long accessTtlMs;
+    
     private final StringRedisTemplate redisTemplate;
-
 
     private String keyFor(Long userId) {
         return REFRESH_TOKEN_PREFIX + userId;
+    }
+
+    private String blacklistKeyFor(String accessToken) {
+        return ACCESS_TOKEN_BLACKLIST_PREFIX + accessToken;
     }
 
     // 로그인 시, 새 리프레시 토큰 저장
@@ -31,6 +42,7 @@ public class RefreshTokenService {
         String saved = redisTemplate.opsForValue().get(keyFor(userId));
         return refreshToken.equals(saved);
     }
+    
     // 토큰 회전: old→new 교체
     public void rotateRefresh(Long userId, String newRefreshToken) {
         redisTemplate.opsForValue()
@@ -42,4 +54,38 @@ public class RefreshTokenService {
         redisTemplate.delete(keyFor(userId));
     }
 
+
+    // ==================== Access Token 블랙리스트 ====================
+    
+    /**
+     * Access Token을 블랙리스트에 추가합니다.
+     * 로그아웃 시 호출됩니다.
+     */
+    public void blacklistAccessToken(String accessToken) {
+        String blacklistKey = blacklistKeyFor(accessToken);
+        // Access Token의 남은 유효시간만큼 블랙리스트에 저장
+        redisTemplate.opsForValue()
+                .set(blacklistKey, "blacklisted", Duration.ofMillis(accessTtlMs));
+    }
+    
+    /**
+     * Access Token이 블랙리스트에 있는지 확인합니다.
+     * JWT 필터에서 호출됩니다.
+     */
+    public boolean isAccessTokenBlacklisted(String accessToken) {
+        String blacklistKey = blacklistKeyFor(accessToken);
+        String blacklisted = redisTemplate.opsForValue().get(blacklistKey);
+        return blacklisted != null;
+    }
+    
+    /**
+     * 모든 토큰을 삭제합니다 (로그아웃 시).
+     */
+    public void logoutUser(Long userId, String accessToken) {
+        // 1. Refresh Token 삭제
+        deleteRefresh(userId);
+        
+        // 2. Access Token 블랙리스트 추가
+        blacklistAccessToken(accessToken);
+    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -39,3 +39,6 @@ loki:
   url: ${LOKI_URL}
   username: ${LOKI_USERNAME}
   password: ${LOKI_PASSWORD}
+
+cookie:
+  secure: true  # HTTPS 환경

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -39,3 +39,6 @@ loki:
   url: ${LOKI_URL}
   username: ${LOKI_USERNAME}
   password: ${LOKI_PASSWORD}
+
+cookie:
+  secure: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -41,3 +41,6 @@ loki:
   url: ${LOKI_URL}
   username: ${LOKI_USERNAME}
   password: ${LOKI_PASSWORD}
+
+cookie:
+  secure: true  # HTTPS 환경


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 로그아웃 API 개발
- 리프레시 토큰 무효화 쿠키 발급
- 액세스 토큰 블랙리스트 등록

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 로그아웃 API가 추가되어 사용자가 로그아웃 시 모든 토큰이 무효화되고, 리프레시 토큰 쿠키가 즉시 삭제됩니다.
  * 블랙리스트 처리로 로그아웃된 액세스 토큰의 재사용이 차단됩니다.
  * 쿠키 보안 설정이 환경별로 적용되어 보안성이 강화되었습니다.
  * 로그아웃 응답에 성공 여부를 나타내는 데이터가 포함됩니다.

* **문서화**
  * 로그아웃 엔드포인트에 대한 API 명세가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->