### PR TITLE
[Y26W2-201] 여행보드 나가기 API 개발

### DIFF
--- a/src/main/java/com/yapp/backend/common/exception/CustomException.java
+++ b/src/main/java/com/yapp/backend/common/exception/CustomException.java
@@ -16,4 +16,15 @@ public class CustomException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+
+    // 원인 체이닝 지원 생성자 추가
+    public CustomException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     INVALID_TRAVEL_PERIOD("유효하지 않은 여행 기간", "유효하지 않은 여행 기간입니다.", HttpStatus.BAD_REQUEST),
     TRIP_BOARD_NOT_FOUND("여행보드 존재하지 않음", "여행보드를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     TRIP_BOARD_UPDATE_FAILED("여행보드 수정 실패", "여행보드 수정에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    TRIP_BOARD_LEAVE_FAILED("여행보드 나가기 실패", "여행보드 나가기 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     TRIP_BOARD_DELETE_FAILED("여행보드 삭제 실패", "여행보드 삭제 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // OAuth related errors

--- a/src/main/java/com/yapp/backend/common/exception/TripBoardLeaveException.java
+++ b/src/main/java/com/yapp/backend/common/exception/TripBoardLeaveException.java
@@ -5,6 +5,10 @@ package com.yapp.backend.common.exception;
  */
 public class TripBoardLeaveException extends CustomException {
 
+    public TripBoardLeaveException() {
+        super(ErrorCode.TRIP_BOARD_LEAVE_FAILED);
+    }
+
     public TripBoardLeaveException(ErrorCode errorCode) {
         super(errorCode);
     }

--- a/src/main/java/com/yapp/backend/common/exception/TripBoardLeaveException.java
+++ b/src/main/java/com/yapp/backend/common/exception/TripBoardLeaveException.java
@@ -1,0 +1,15 @@
+package com.yapp.backend.common.exception;
+
+/**
+ * 여행보드 나가기 관련 예외 클래스
+ */
+public class TripBoardLeaveException extends CustomException {
+
+    public TripBoardLeaveException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public TripBoardLeaveException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/yapp/backend/controller/TripBoardController.java
+++ b/src/main/java/com/yapp/backend/controller/TripBoardController.java
@@ -136,7 +136,7 @@ public class TripBoardController implements TripBoardDocs {
      * 여행 보드 나가기 API
      */
     @Override
-    @PostMapping("/{tripBoardId}/leave")
+    @PostMapping("/leave/{tripBoardId}")
     public ResponseEntity<StandardResponse<TripBoardLeaveResponse>> leaveTripBoard(
             @PathVariable Long tripBoardId,
             @RequestBody @Valid TripBoardLeaveRequest request,
@@ -144,6 +144,9 @@ public class TripBoardController implements TripBoardDocs {
 
         // JWT 인증을 통한 현재 사용자 정보 추출
         Long whoAmI = userDetails.getUserId();
+
+        // 여행 보드 접근 권한 검증
+        authorizationService.validateTripBoardAccess(whoAmI, tripBoardId);
 
         // 여행 보드 나가기
         TripBoardLeaveResponse response = tripBoardService.leaveTripBoard(

--- a/src/main/java/com/yapp/backend/controller/TripBoardController.java
+++ b/src/main/java/com/yapp/backend/controller/TripBoardController.java
@@ -4,8 +4,10 @@ import com.yapp.backend.common.response.ResponseType;
 import com.yapp.backend.common.response.StandardResponse;
 import com.yapp.backend.controller.docs.TripBoardDocs;
 import com.yapp.backend.controller.dto.request.TripBoardCreateRequest;
+import com.yapp.backend.controller.dto.request.TripBoardLeaveRequest;
 import com.yapp.backend.controller.dto.request.TripBoardUpdateRequest;
 import com.yapp.backend.controller.dto.response.TripBoardCreateResponse;
+import com.yapp.backend.controller.dto.response.TripBoardLeaveResponse;
 import com.yapp.backend.controller.dto.response.TripBoardDeleteResponse;
 import com.yapp.backend.controller.dto.response.TripBoardPageResponse;
 import com.yapp.backend.controller.dto.response.TripBoardUpdateResponse;
@@ -126,6 +128,26 @@ public class TripBoardController implements TripBoardDocs {
 
         // 여행 보드 삭제 (소유자 권한 검증 포함)
         TripBoardDeleteResponse response = tripBoardService.deleteTripBoard(tripBoardId, whoAmI);
+
+        return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
+    }
+
+    /**
+     * 여행 보드 나가기 API
+     */
+    @Override
+    @PostMapping("/{tripBoardId}/leave")
+    public ResponseEntity<StandardResponse<TripBoardLeaveResponse>> leaveTripBoard(
+            @PathVariable Long tripBoardId,
+            @RequestBody @Valid TripBoardLeaveRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        // JWT 인증을 통한 현재 사용자 정보 추출
+        Long whoAmI = userDetails.getUserId();
+
+        // 여행 보드 나가기
+        TripBoardLeaveResponse response = tripBoardService.leaveTripBoard(
+                tripBoardId, whoAmI, request.getRemoveResources());
 
         return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
     }

--- a/src/main/java/com/yapp/backend/controller/docs/TripBoardDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/TripBoardDocs.java
@@ -2,8 +2,10 @@ package com.yapp.backend.controller.docs;
 
 import com.yapp.backend.common.response.StandardResponse;
 import com.yapp.backend.controller.dto.request.TripBoardCreateRequest;
+import com.yapp.backend.controller.dto.request.TripBoardLeaveRequest;
 import com.yapp.backend.controller.dto.request.TripBoardUpdateRequest;
 import com.yapp.backend.controller.dto.response.TripBoardCreateResponse;
+import com.yapp.backend.controller.dto.response.TripBoardLeaveResponse;
 import com.yapp.backend.controller.dto.response.TripBoardDeleteResponse;
 import com.yapp.backend.controller.dto.response.TripBoardPageResponse;
 import com.yapp.backend.controller.dto.response.TripBoardUpdateResponse;
@@ -51,5 +53,12 @@ public interface TripBoardDocs {
         @SecurityRequirement(name = "JWT")
         ResponseEntity<StandardResponse<TripBoardDeleteResponse>> deleteTripBoard(
                         @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "여행 보드 ID") @PathVariable Long tripBoardId,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+
+        @Operation(summary = "여행 보드 나가기", description = "여행 보드에서 나갑니다. OWNER인 경우 가장 먼저 입장한 MEMBER에게 권한이 이양되며, 마지막 참여자인 경우 여행보드가 삭제됩니다. 나가는 사용자는 자신이 생성한 리소스(비교표, 숙소)를 유지하거나 제거할 수 있습니다.")
+        @SecurityRequirement(name = "JWT")
+        ResponseEntity<StandardResponse<TripBoardLeaveResponse>> leaveTripBoard(
+                        @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "여행 보드 ID") @PathVariable Long tripBoardId,
+                        @RequestBody @Valid TripBoardLeaveRequest request,
                         @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/com/yapp/backend/controller/dto/request/TripBoardLeaveRequest.java
+++ b/src/main/java/com/yapp/backend/controller/dto/request/TripBoardLeaveRequest.java
@@ -1,0 +1,20 @@
+package com.yapp.backend.controller.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 여행보드 나가기 요청 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripBoardLeaveRequest {
+
+    @NotNull(message = "리소스 제거 여부를 선택해주세요")
+    private Boolean removeResources;
+}

--- a/src/main/java/com/yapp/backend/controller/dto/response/TripBoardLeaveResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/TripBoardLeaveResponse.java
@@ -1,0 +1,21 @@
+package com.yapp.backend.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 여행보드 나가기 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripBoardLeaveResponse {
+
+    private Long tripBoardId;
+    private LocalDateTime leftAt;
+}

--- a/src/main/java/com/yapp/backend/repository/AccommodationRepository.java
+++ b/src/main/java/com/yapp/backend/repository/AccommodationRepository.java
@@ -32,13 +32,17 @@ public interface AccommodationRepository {
 
     /**
      * 숙소 ID로 조회, 실패시 에러를 던집니다.
-     * 
      * @param accommodationId
      * @return
      */
     Accommodation findByIdOrThrow(Long accommodationId);
 
     void update(Accommodation updatedAccommodation);
+
+    /**
+     * 특정 여행보드에서 특정 사용자가 생성한 숙소들을 삭제합니다.
+     */
+    void deleteByBoardIdAndCreatedById(Long boardId, Long createdById);
 
     /**
      * 여행보드 ID로 해당 보드의 모든 숙소를 삭제합니다.

--- a/src/main/java/com/yapp/backend/repository/ComparisonTableRepository.java
+++ b/src/main/java/com/yapp/backend/repository/ComparisonTableRepository.java
@@ -15,13 +15,12 @@ public interface ComparisonTableRepository {
     ComparisonTable addAccommodationsToTable(Long tableId, java.util.List<Long> accommodationIds, Long userId);
 
     /**
-     * 여행보드 ID로 해당 보드의 모든 비교표를 삭제합니다.
-     */
-    void deleteByTripBoardId(Long tripBoardId);
-}
-
-    /**
      * 특정 여행보드에서 특정 사용자가 생성한 비교표들을 삭제합니다.
      */
     void deleteByTripBoardIdAndCreatedById(Long tripBoardId, Long createdById);
+
+    /**
+     * 특정 여행보드의 모든 비교표를 삭제합니다 (여행보드 완전 삭제용).
+     */
+    void deleteByTripBoardId(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/ComparisonTableRepository.java
+++ b/src/main/java/com/yapp/backend/repository/ComparisonTableRepository.java
@@ -19,3 +19,9 @@ public interface ComparisonTableRepository {
      */
     void deleteByTripBoardId(Long tripBoardId);
 }
+
+    /**
+     * 특정 여행보드에서 특정 사용자가 생성한 비교표들을 삭제합니다.
+     */
+    void deleteByTripBoardIdAndCreatedById(Long tripBoardId, Long createdById);
+}

--- a/src/main/java/com/yapp/backend/repository/JpaAccommodationRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaAccommodationRepository.java
@@ -57,6 +57,16 @@ public interface JpaAccommodationRepository extends JpaRepository<AccommodationE
                         @Param("userId") Long userId, Pageable pageable);
 
         /**
+         * 특정 여행보드에서 특정 사용자가 생성한 숙소들을 삭제
+         */
+        void deleteByBoardIdAndCreatedById(Long boardId, Long createdById);
+
+        /**
+         * 특정 여행보드의 모든 숙소를 삭제 (여행보드 완전 삭제용)
+         */
+        void deleteByBoardId(Long boardId);
+
+        /**
          * 여행보드 ID로 해당 보드의 모든 숙소를 삭제합니다.
          */
         void deleteByBoardId(Long boardId);

--- a/src/main/java/com/yapp/backend/repository/JpaAccommodationRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaAccommodationRepository.java
@@ -65,9 +65,4 @@ public interface JpaAccommodationRepository extends JpaRepository<AccommodationE
          * 특정 여행보드의 모든 숙소를 삭제 (여행보드 완전 삭제용)
          */
         void deleteByBoardId(Long boardId);
-
-        /**
-         * 여행보드 ID로 해당 보드의 모든 숙소를 삭제합니다.
-         */
-        void deleteByBoardId(Long boardId);
 }

--- a/src/main/java/com/yapp/backend/repository/JpaComparisonTableRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaComparisonTableRepository.java
@@ -6,6 +6,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface JpaComparisonTableRepository extends JpaRepository<ComparisonTableEntity, Long> {
 
     /**
+     * 특정 여행보드에서 특정 사용자가 생성한 비교표들을 삭제
+     */
+    void deleteByTripBoardIdAndCreatedByEntityId(Long tripBoardId, Long createdById);
+
+    /**
+     * 특정 여행보드의 모든 비교표를 삭제 (여행보드 완전 삭제용)
+     */
+    void deleteByTripBoardId(Long tripBoardId);
+}
+
+    /**
      * 여행보드 ID로 해당 보드의 모든 비교표를 삭제합니다.
      */
     void deleteByTripBoardEntityId(Long tripBoardId);

--- a/src/main/java/com/yapp/backend/repository/JpaComparisonTableRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaComparisonTableRepository.java
@@ -8,16 +8,10 @@ public interface JpaComparisonTableRepository extends JpaRepository<ComparisonTa
     /**
      * 특정 여행보드에서 특정 사용자가 생성한 비교표들을 삭제
      */
-    void deleteByTripBoardIdAndCreatedByEntityId(Long tripBoardId, Long createdById);
+    void deleteByTripBoardEntityIdAndCreatedByEntityId(Long tripBoardId, Long createdById);
 
     /**
      * 특정 여행보드의 모든 비교표를 삭제 (여행보드 완전 삭제용)
-     */
-    void deleteByTripBoardId(Long tripBoardId);
-}
-
-    /**
-     * 여행보드 ID로 해당 보드의 모든 비교표를 삭제합니다.
      */
     void deleteByTripBoardEntityId(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/JpaUserTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaUserTripBoardRepository.java
@@ -1,6 +1,7 @@
 package com.yapp.backend.repository;
 
 import com.yapp.backend.repository.entity.UserTripBoardEntity;
+import com.yapp.backend.repository.enums.TripBoardRole;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -60,6 +61,21 @@ public interface JpaUserTripBoardRepository extends JpaRepository<UserTripBoardE
 
         /**
          * 여행보드 ID로 해당 보드의 모든 사용자 매핑을 삭제합니다.
+         */
+        void deleteByTripBoardId(Long tripBoardId);
+
+        /**
+         * 여행보드의 특정 역할 참여자를 생성일 오름차순으로 조회 (다음 OWNER 후보 조회용)
+         */
+        List<UserTripBoardEntity> findByTripBoardIdAndRoleOrderByCreatedAtAsc(Long tripBoardId, TripBoardRole role);
+
+        /**
+         * 사용자와 여행보드 간의 매핑 삭제
+         */
+        void deleteByUserIdAndTripBoardId(Long userId, Long tripBoardId);
+
+        /**
+         * 특정 여행보드의 모든 사용자-여행보드 매핑을 삭제 (여행보드 완전 삭제용)
          */
         void deleteByTripBoardId(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/JpaUserTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaUserTripBoardRepository.java
@@ -14,63 +14,68 @@ import java.util.Optional;
 
 @Repository
 public interface JpaUserTripBoardRepository extends JpaRepository<UserTripBoardEntity, Long> {
-        /**
-         * 초대 링크 존재 여부 확인
-         */
-        boolean existsByInvitationUrl(String invitationUrl);
+    /**
+     * 초대 링크 존재 여부 확인
+     */
+    boolean existsByInvitationUrl(String invitationUrl);
 
-        /**
-         * 사용자 ID와 여행 보드 ID로 매핑 정보 조회
-         */
-        Optional<UserTripBoardEntity> findByUserIdAndTripBoardId(Long userId, Long tripBoardId);
+    /**
+     * 사용자 ID와 여행 보드 ID로 매핑 정보 조회
+     */
+    Optional<UserTripBoardEntity> findByUserIdAndTripBoardId(Long userId, Long tripBoardId);
 
-        /**
-         * 활성화된 초대 링크로 매핑 정보 조회
-         */
-        Optional<UserTripBoardEntity> findByInvitationUrlAndInvitationActiveTrue(String invitationUrl);
+    /**
+     * 활성화된 초대 링크로 매핑 정보 조회
+     */
+    Optional<UserTripBoardEntity> findByInvitationUrlAndInvitationActiveTrue(String invitationUrl);
 
-        /**
-         * 여행 보드의 참여자 수 조회
-         */
-        long countByTripBoardId(Long tripBoardId);
+    /**
+     * 여행 보드의 참여자 수 조회
+     */
+    long countByTripBoardId(Long tripBoardId);
 
-        /**
-         * 사용자가 참여한 여행 보드 목록을 페이징하여 조회 (최신순 정렬)
-         * 생성일 내림차순, ID 내림차순으로 정렬
-         */
-        @Query("SELECT utb FROM UserTripBoardEntity utb " +
-                        "JOIN FETCH utb.tripBoard tb " +
-                        "WHERE utb.user.id = :userId " +
-                        "ORDER BY tb.createdAt DESC, tb.id DESC")
-        Page<UserTripBoardEntity> findByUserIdOrderByTripBoardCreatedAtDescIdDesc(@Param("userId") Long userId,
-                        Pageable pageable);
+    /**
+     * 사용자가 참여한 여행 보드 목록을 페이징하여 조회 (최신순 정렬)
+     * 생성일 내림차순, ID 내림차순으로 정렬
+     */
+    @Query("SELECT utb FROM UserTripBoardEntity utb " +
+            "JOIN FETCH utb.tripBoard tb " +
+            "WHERE utb.user.id = :userId " +
+            "ORDER BY tb.createdAt DESC, tb.id DESC")
+    Page<UserTripBoardEntity> findByUserIdOrderByTripBoardCreatedAtDescIdDesc(@Param("userId") Long userId,
+                                                                              Pageable pageable);
 
-        /**
-         * 사용자가 참여한 여행 보드 개수 조회
-         */
-        @Query("SELECT COUNT(utb) FROM UserTripBoardEntity utb WHERE utb.user.id = :userId")
-        long countByUserId(@Param("userId") Long userId);
+    /**
+     * 사용자가 참여한 여행 보드 개수 조회
+     */
+    @Query("SELECT COUNT(utb) FROM UserTripBoardEntity utb WHERE utb.user.id = :userId")
+    long countByUserId(@Param("userId") Long userId);
 
-        /**
-         * 여러 여행 보드의 모든 참여자를 한 번에 조회 (IN 절)
-         */
-        @Query("SELECT utb FROM UserTripBoardEntity utb " +
-                        "JOIN FETCH utb.user u " +
-                        "WHERE utb.tripBoard.id IN :tripBoardIds")
-        List<UserTripBoardEntity> findByTripBoardIdsWithUser(@Param("tripBoardIds") List<Long> tripBoardIds);
+    /**
+     * 여러 여행 보드의 모든 참여자를 한 번에 조회 (IN 절)
+     */
+    @Query("SELECT utb FROM UserTripBoardEntity utb " +
+            "JOIN FETCH utb.user u " +
+            "WHERE utb.tripBoard.id IN :tripBoardIds")
+    List<UserTripBoardEntity> findByTripBoardIdsWithUser(@Param("tripBoardIds") List<Long> tripBoardIds);
 
-        /**
-         * 여행보드의 특정 역할 참여자를 생성일 오름차순으로 조회 (다음 OWNER 후보 조회용)
-         */
-        List<UserTripBoardEntity> findByTripBoardIdAndRoleOrderByCreatedAtAsc(Long tripBoardId, TripBoardRole role);
+    /**
+     * 여행보드의 특정 역할 참여자를 생성일 오름차순으로 조회 (다음 OWNER 후보 조회용)
+     */
+    List<UserTripBoardEntity> findByTripBoardIdAndRoleOrderByCreatedAtAsc(Long tripBoardId, TripBoardRole role);
 
-        /**
-         * 사용자와 여행보드 간의 매핑 삭제
-         */
-        void deleteByUserIdAndTripBoardId(Long userId, Long tripBoardId);
+    /**
+     * 사용자와 여행보드 간의 매핑 삭제
+     */
+    void deleteByUserIdAndTripBoardId(Long userId, Long tripBoardId);
 
-        /**
-         * 특정 여행보드의 모든 사용자-여행보드 매핑을 삭제 (여행보드 완전 삭제용)
-         */
-        void deleteByTripBoardId(Long tripBoardId);
+    /**
+     * 특정 여행보드의 모든 사용자-여행보드 매핑을 삭제 (여행보드 완전 삭제용)
+     */
+    void deleteByTripBoardId(Long tripBoardId);
+
+    /**
+     * tripBoardId로 존재 여부만 확인합니다.
+     */
+    boolean existsByTripBoardId(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/JpaUserTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaUserTripBoardRepository.java
@@ -60,11 +60,6 @@ public interface JpaUserTripBoardRepository extends JpaRepository<UserTripBoardE
         List<UserTripBoardEntity> findByTripBoardIdsWithUser(@Param("tripBoardIds") List<Long> tripBoardIds);
 
         /**
-         * 여행보드 ID로 해당 보드의 모든 사용자 매핑을 삭제합니다.
-         */
-        void deleteByTripBoardId(Long tripBoardId);
-
-        /**
          * 여행보드의 특정 역할 참여자를 생성일 오름차순으로 조회 (다음 OWNER 후보 조회용)
          */
         List<UserTripBoardEntity> findByTripBoardIdAndRoleOrderByCreatedAtAsc(Long tripBoardId, TripBoardRole role);

--- a/src/main/java/com/yapp/backend/repository/TripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/TripBoardRepository.java
@@ -42,6 +42,11 @@ public interface TripBoardRepository {
     TripBoard updateTripBoard(TripBoard tripBoard);
 
     /**
+     * 여행보드를 완전히 삭제합니다 (관련된 모든 데이터 포함).
+     */
+    void deleteTripBoardCompletely(Long tripBoardId);
+
+    /**
      * ID로 여행 보드를 삭제합니다.
      */
     void deleteById(Long id);

--- a/src/main/java/com/yapp/backend/repository/TripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/TripBoardRepository.java
@@ -55,4 +55,9 @@ public interface TripBoardRepository {
      * 여행 보드 ID와 생성자 ID로 여행 보드를 조회합니다. (소유자 검증용)
      */
     Optional<TripBoard> findByIdAndCreatedById(Long tripBoardId, Long createdById);
+
+    /**
+     * 여행보드 존재 여부 확인
+     */
+    boolean existsById(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/UserTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/UserTripBoardRepository.java
@@ -1,12 +1,48 @@
 package com.yapp.backend.repository;
 
+import com.yapp.backend.service.model.UserTripBoard;
+import com.yapp.backend.repository.enums.TripBoardRole;
+
+import java.util.List;
+import java.util.Optional;
+
 /**
  * 사용자-여행보드 매핑 Repository 인터페이스
  */
 public interface UserTripBoardRepository {
 
     /**
+     * 사용자 ID와 여행보드 ID로 매핑 정보 조회
+     */
+    Optional<UserTripBoard> findByUserIdAndTripBoardId(Long userId, Long tripBoardId);
+
+    /**
+     * 여행보드의 참여자 수 조회
+     */
+    long countByTripBoardId(Long tripBoardId);
+
+    /**
+     * 여행보드의 특정 역할 참여자를 생성일 오름차순으로 조회 (다음 OWNER 후보 조회용)
+     */
+    List<UserTripBoard> findByTripBoardIdAndRoleOrderByCreatedAtAsc(Long tripBoardId, TripBoardRole role);
+
+    /**
+     * 사용자와 여행보드 간의 매핑 삭제
+     */
+    void deleteByUserIdAndTripBoardId(Long userId, Long tripBoardId);
+
+    /**
      * 여행보드 ID로 해당 보드의 모든 사용자 매핑을 삭제합니다.
      */
     void deleteByTripBoardId(Long tripBoardId);
+
+    /**
+     * 사용자-여행보드 매핑 정보 저장/업데이트
+     */
+    UserTripBoard save(UserTripBoard userTripBoard);
+
+    /**
+     * 여행보드 존재 여부 확인
+     */
+    boolean existsByTripBoardId(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/UserTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/UserTripBoardRepository.java
@@ -40,9 +40,4 @@ public interface UserTripBoardRepository {
      * 사용자-여행보드 매핑 정보 저장/업데이트
      */
     UserTripBoard save(UserTripBoard userTripBoard);
-
-    /**
-     * 여행보드 존재 여부 확인
-     */
-    boolean existsByTripBoardId(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/impl/AccommodationRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/AccommodationRepositoryImpl.java
@@ -39,14 +39,14 @@ public class AccommodationRepositoryImpl implements AccommodationRepository {
         SortType sortType = SortType.fromString(sort);
         boolean isPriceSort = sortType == SortType.PRICE_ASC;
 
-        entityPage = userId != null
-                ? getEntityPageWithUserId(boardId, userId, pageable, isPriceSort)
-                : getEntityPageWithoutUserId(boardId, pageable, isPriceSort);
+		entityPage = userId != null
+				? getEntityPageWithUserId(boardId, userId, pageable, isPriceSort)
+				: getEntityPageWithoutUserId(boardId, pageable, isPriceSort);
 
-        return entityPage.getContent().stream()
-                .map(this::convertToAccommodation)
-                .collect(Collectors.toList());
-    }
+		return entityPage.getContent().stream()
+				.map(this::convertToAccommodation)
+				.collect(Collectors.toList());
+	}
 
     /**
      * 테이블 ID로 숙소 개수를 조회
@@ -77,33 +77,33 @@ public class AccommodationRepositoryImpl implements AccommodationRepository {
         return accommodationMapper.entityToDomain(accommodationEntity);
     }
 
-    /**
-     * 숙소 ID로 단건 조회합니다.
-     */
-    @Override
-    public Accommodation findById(Long accommodationId) {
-        AccommodationEntity entity = jpaAccommodationRepository.findByAccommodationId(accommodationId);
-        return entity != null ? convertToAccommodation(entity) : null;
-    }
+	/**
+	 * 숙소 ID로 단건 조회합니다.
+	 */
+	@Override
+	public Accommodation findById(Long accommodationId) {
+		AccommodationEntity entity = jpaAccommodationRepository.findByAccommodationId(accommodationId);
+		return entity != null ? convertToAccommodation(entity) : null;
+	}
 
-    /**
-     * userId가 있는 경우의 엔티티 페이지 조회
-     */
-    private Page<AccommodationEntity> getEntityPageWithUserId(Long boardId, Long userId, Pageable pageable,
-                                                              boolean isPriceSort) {
-        return isPriceSort
-                ? jpaAccommodationRepository.findByBoardIdAndCreatedByOrderByLowestPriceAsc(boardId, userId, pageable)
-                : jpaAccommodationRepository.findByBoardIdAndCreatedByOrderByCreatedAtDesc(boardId, userId, pageable);
-    }
+	/**
+	 * userId가 있는 경우의 엔티티 페이지 조회
+	 */
+	private Page<AccommodationEntity> getEntityPageWithUserId(Long boardId, Long userId, Pageable pageable,
+			boolean isPriceSort) {
+		return isPriceSort
+				? jpaAccommodationRepository.findByBoardIdAndCreatedByOrderByLowestPriceAsc(boardId, userId, pageable)
+				: jpaAccommodationRepository.findByBoardIdAndCreatedByOrderByCreatedAtDesc(boardId, userId, pageable);
+	}
 
-    /**
-     * userId가 없는 경우의 엔티티 페이지 조회
-     */
-    private Page<AccommodationEntity> getEntityPageWithoutUserId(Long boardId, Pageable pageable, boolean isPriceSort) {
-        return isPriceSort
-                ? jpaAccommodationRepository.findByBoardIdOrderByLowestPriceAsc(boardId, pageable)
-                : jpaAccommodationRepository.findByBoardIdOrderByCreatedAtDesc(boardId, pageable);
-    }
+	/**
+	 * userId가 없는 경우의 엔티티 페이지 조회
+	 */
+	private Page<AccommodationEntity> getEntityPageWithoutUserId(Long boardId, Pageable pageable, boolean isPriceSort) {
+		return isPriceSort
+				? jpaAccommodationRepository.findByBoardIdOrderByLowestPriceAsc(boardId, pageable)
+				: jpaAccommodationRepository.findByBoardIdOrderByCreatedAtDesc(boardId, pageable);
+	}
 
     /**
      * Convert AccommodationEntity to Accommodation domain model
@@ -122,5 +122,10 @@ public class AccommodationRepositoryImpl implements AccommodationRepository {
     public void deleteByBoardId(Long boardId) {
         jpaAccommodationRepository.deleteByBoardId(boardId);
     }
+
+	@Override
+	public void deleteByBoardIdAndCreatedById(Long boardId, Long createdById) {
+		jpaAccommodationRepository.deleteByBoardIdAndCreatedById(boardId, createdById);
+	}
 
 }

--- a/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
@@ -156,7 +156,7 @@ public class ComparisonTableRepositoryImpl implements ComparisonTableRepository 
     @Override
     @Transactional
     public void deleteByTripBoardIdAndCreatedById(Long tripBoardId, Long createdById) {
-        jpaComparisonTableRepository.deleteByTripBoardIdAndCreatedByEntityId(tripBoardId, createdById);
+        jpaComparisonTableRepository.deleteByTripBoardEntityIdAndCreatedByEntityId(tripBoardId, createdById);
     }
 
     @Override

--- a/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
@@ -154,6 +154,12 @@ public class ComparisonTableRepositoryImpl implements ComparisonTableRepository 
     }
 
     @Override
+    @Transactional
+    public void deleteByTripBoardIdAndCreatedById(Long tripBoardId, Long createdById) {
+        jpaComparisonTableRepository.deleteByTripBoardIdAndCreatedByEntityId(tripBoardId, createdById);
+    }
+
+    @Override
     public void deleteByTripBoardId(Long tripBoardId) {
         jpaComparisonTableRepository.deleteByTripBoardEntityId(tripBoardId);
     }

--- a/src/main/java/com/yapp/backend/repository/impl/TripBoardRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/TripBoardRepositoryImpl.java
@@ -113,11 +113,16 @@ public class TripBoardRepositoryImpl implements TripBoardRepository {
     }
 
     @Override
+    public boolean existsById(Long tripBoardId) {
+        return jpaTripBoardRepository.existsById(tripBoardId);
+    }
+
+    @Override
     @Transactional
     public void deleteTripBoardCompletely(Long tripBoardId) {
         // 여행보드와 관련된 모든 데이터를 순서대로 삭제합니다.
         // 1. 비교표 삭제 (ComparisonAccommodation 매핑도 cascade로 함께 삭제됨)
-        jpaComparisonTableRepository.deleteByTripBoardId(tripBoardId);
+        jpaComparisonTableRepository.deleteByTripBoardEntityId(tripBoardId);
 
         // 2. 숙소 삭제
         jpaAccommodationRepository.deleteByBoardId(tripBoardId);

--- a/src/main/java/com/yapp/backend/repository/impl/UserTripBoardRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/UserTripBoardRepositoryImpl.java
@@ -2,8 +2,16 @@ package com.yapp.backend.repository.impl;
 
 import com.yapp.backend.repository.JpaUserTripBoardRepository;
 import com.yapp.backend.repository.UserTripBoardRepository;
+import com.yapp.backend.repository.entity.UserTripBoardEntity;
+import com.yapp.backend.repository.enums.TripBoardRole;
+import com.yapp.backend.repository.mapper.UserTripBoardMapper;
+import com.yapp.backend.service.model.UserTripBoard;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * 사용자-여행보드 매핑 Repository 구현체
@@ -13,9 +21,46 @@ import org.springframework.stereotype.Repository;
 public class UserTripBoardRepositoryImpl implements UserTripBoardRepository {
 
     private final JpaUserTripBoardRepository jpaUserTripBoardRepository;
+    private final UserTripBoardMapper userTripBoardMapper;
+
+    @Override
+    public Optional<UserTripBoard> findByUserIdAndTripBoardId(Long userId, Long tripBoardId) {
+        return jpaUserTripBoardRepository.findByUserIdAndTripBoardId(userId, tripBoardId)
+                .map(userTripBoardMapper::entityToDomain);
+    }
+
+    @Override
+    public long countByTripBoardId(Long tripBoardId) {
+        return jpaUserTripBoardRepository.countByTripBoardId(tripBoardId);
+    }
+
+    @Override
+    public List<UserTripBoard> findByTripBoardIdAndRoleOrderByCreatedAtAsc(Long tripBoardId, TripBoardRole role) {
+        return jpaUserTripBoardRepository.findByTripBoardIdAndRoleOrderByCreatedAtAsc(tripBoardId, role)
+                .stream()
+                .map(userTripBoardMapper::entityToDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteByUserIdAndTripBoardId(Long userId, Long tripBoardId) {
+        jpaUserTripBoardRepository.deleteByUserIdAndTripBoardId(userId, tripBoardId);
+    }
 
     @Override
     public void deleteByTripBoardId(Long tripBoardId) {
         jpaUserTripBoardRepository.deleteByTripBoardId(tripBoardId);
+    }
+
+    @Override
+    public UserTripBoard save(UserTripBoard userTripBoard) {
+        UserTripBoardEntity entity = userTripBoardMapper.domainToEntity(userTripBoard);
+        UserTripBoardEntity savedEntity = jpaUserTripBoardRepository.save(entity);
+        return userTripBoardMapper.entityToDomain(savedEntity);
+    }
+
+    @Override
+    public boolean existsByTripBoardId(Long tripBoardId) {
+        return jpaUserTripBoardRepository.countByTripBoardId(tripBoardId) > 0;
     }
 }

--- a/src/main/java/com/yapp/backend/repository/impl/UserTripBoardRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/UserTripBoardRepositoryImpl.java
@@ -39,7 +39,7 @@ public class UserTripBoardRepositoryImpl implements UserTripBoardRepository {
         return jpaUserTripBoardRepository.findByTripBoardIdAndRoleOrderByCreatedAtAsc(tripBoardId, role)
                 .stream()
                 .map(userTripBoardMapper::entityToDomain)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override
@@ -57,10 +57,5 @@ public class UserTripBoardRepositoryImpl implements UserTripBoardRepository {
         UserTripBoardEntity entity = userTripBoardMapper.domainToEntity(userTripBoard);
         UserTripBoardEntity savedEntity = jpaUserTripBoardRepository.save(entity);
         return userTripBoardMapper.entityToDomain(savedEntity);
-    }
-
-    @Override
-    public boolean existsByTripBoardId(Long tripBoardId) {
-        return jpaUserTripBoardRepository.countByTripBoardId(tripBoardId) > 0;
     }
 }

--- a/src/main/java/com/yapp/backend/service/TripBoardService.java
+++ b/src/main/java/com/yapp/backend/service/TripBoardService.java
@@ -4,6 +4,7 @@ import com.yapp.backend.controller.dto.request.TripBoardCreateRequest;
 import com.yapp.backend.controller.dto.request.TripBoardUpdateRequest;
 import com.yapp.backend.controller.dto.response.TripBoardCreateResponse;
 import com.yapp.backend.controller.dto.response.TripBoardDeleteResponse;
+import com.yapp.backend.controller.dto.response.TripBoardLeaveResponse;
 import com.yapp.backend.controller.dto.response.TripBoardPageResponse;
 import com.yapp.backend.controller.dto.response.TripBoardUpdateResponse;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +15,8 @@ public interface TripBoardService {
     TripBoardPageResponse getTripBoards(Long userId, Pageable pageable);
 
     TripBoardUpdateResponse updateTripBoard(Long tripBoardId, TripBoardUpdateRequest request, Long userId);
+
+    TripBoardLeaveResponse leaveTripBoard(Long tripBoardId, Long userId, Boolean removeResources);
 
     TripBoardDeleteResponse deleteTripBoard(Long tripBoardId, Long userId);
 }

--- a/src/main/java/com/yapp/backend/service/impl/TripBoardServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/TripBoardServiceImpl.java
@@ -4,6 +4,7 @@ import com.yapp.backend.common.exception.InvalidDestinationException;
 import com.yapp.backend.common.exception.InvalidPagingParameterException;
 import com.yapp.backend.common.exception.InvalidTravelPeriodException;
 import com.yapp.backend.common.exception.TripBoardCreationException;
+import com.yapp.backend.common.exception.TripBoardLeaveException;
 import com.yapp.backend.common.exception.TripBoardDeleteException;
 import com.yapp.backend.common.exception.TripBoardNotFoundException;
 import com.yapp.backend.common.exception.TripBoardParticipantLimitExceededException;
@@ -14,12 +15,17 @@ import com.yapp.backend.common.util.PageUtil;
 import com.yapp.backend.controller.dto.request.TripBoardCreateRequest;
 import com.yapp.backend.controller.dto.request.TripBoardUpdateRequest;
 import com.yapp.backend.controller.dto.response.TripBoardCreateResponse;
+import com.yapp.backend.controller.dto.response.TripBoardLeaveResponse;
 import com.yapp.backend.controller.dto.response.TripBoardDeleteResponse;
 import com.yapp.backend.controller.dto.response.TripBoardPageResponse;
 import com.yapp.backend.controller.dto.response.TripBoardSummaryResponse;
 import com.yapp.backend.controller.dto.response.TripBoardUpdateResponse;
 import com.yapp.backend.controller.mapper.TripBoardSummaryMapper;
 import com.yapp.backend.controller.mapper.TripBoardUpdateMapper;
+import com.yapp.backend.repository.AccommodationRepository;
+import com.yapp.backend.repository.ComparisonTableRepository;
+import com.yapp.backend.repository.JpaAccommodationRepository;
+import com.yapp.backend.repository.JpaComparisonTableRepository;
 import com.yapp.backend.repository.AccommodationRepository;
 import com.yapp.backend.repository.ComparisonTableRepository;
 import com.yapp.backend.repository.JpaTripBoardRepository;
@@ -49,7 +55,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -63,9 +71,14 @@ public class TripBoardServiceImpl implements TripBoardService {
     private static final int MAX_PARTICIPANTS = 10;
 
     private final JpaTripBoardRepository jpaTripBoardRepository;
+    private final JpaUserTripBoardRepository userTripBoardRepository;
+    private final JpaAccommodationRepository jpaAccommodationRepository;
+    private final JpaComparisonTableRepository jpaComparisonTableRepository;
     private final JpaUserTripBoardRepository jpaUserTripBoardRepository;
     private final TripBoardRepository tripBoardRepository;
     private final UserRepository userRepository;
+    private final AccommodationRepository accommodationRepository;
+    private final ComparisonTableRepository comparisonTableRepository;
     private final AccommodationRepository accommodationRepository;
     private final ComparisonTableRepository comparisonTableRepository;
     private final UserTripBoardRepository userTripBoardRepository;
@@ -359,6 +372,166 @@ public class TripBoardServiceImpl implements TripBoardService {
             log.error("관련 데이터 삭제 중 오류 발생 - 보드 ID: {}", tripBoardId, e);
             throw e;
         }
+    }
+
+    /**
+     * 여행보드 나가기
+     * OWNER가 나가는 경우 다음 MEMBER에게 권한을 이양하고, 마지막 참여자인 경우 여행보드를 완전 삭제합니다.
+     */
+    @Override
+    @Transactional
+    public TripBoardLeaveResponse leaveTripBoard(Long tripBoardId, Long userId, Boolean removeResources) {
+        try {
+            log.info("여행보드 나가기 시작 - 보드 ID: {}, 사용자 ID: {}, 리소스 제거: {}",
+                    tripBoardId, userId, removeResources);
+
+            // 1. 여행보드 존재 여부 확인
+            if (!jpaTripBoardRepository.existsById(tripBoardId)) {
+                log.warn("존재하지 않는 여행보드 나가기 시도 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId);
+                throw new TripBoardNotFoundException();
+            }
+
+            // 2. 사용자가 해당 여행보드의 참여자인지 확인
+            Optional<UserTripBoardEntity> userTripBoardOpt = userTripBoardRepository
+                    .findByUserIdAndTripBoardId(userId, tripBoardId);
+
+            if (userTripBoardOpt.isEmpty()) {
+                log.warn("참여하지 않은 여행보드 나가기 시도 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId);
+                throw new UserAuthorizationException();
+            }
+
+            UserTripBoardEntity currentUserTripBoard = userTripBoardOpt.get();
+            TripBoardRole currentUserRole = currentUserTripBoard.getRole();
+
+            log.debug("사용자 역할 확인 - 사용자 ID: {}, 역할: {}", userId, currentUserRole);
+
+            // 3. 전체 참여자 수 확인
+            long totalParticipants = userTripBoardRepository.countByTripBoardId(tripBoardId);
+            boolean isLastParticipant = totalParticipants == 1;
+
+            log.debug("참여자 수 확인 - 전체 참여자: {}, 마지막 참여자 여부: {}", totalParticipants, isLastParticipant);
+
+            // 4. 응답 객체 초기화
+            TripBoardLeaveResponse tripBoardLeaveResponse = TripBoardLeaveResponse.builder()
+                    .tripBoardId(tripBoardId)
+                    .leftAt(LocalDateTime.now())
+                    .build();
+
+            // 5. 마지막 참여자인 경우 여행보드 완전 삭제
+            if (isLastParticipant) {
+                log.info("마지막 참여자 나가기 - 여행보드 완전 삭제 시작: 보드 ID: {}", tripBoardId);
+                deleteTripBoardCompletely(tripBoardId);
+                log.info("여행보드 완전 삭제 완료 - 보드 ID: {}", tripBoardId);
+            } else {
+                // 6. OWNER 권한 이양 처리 (OWNER인 경우)
+                if (currentUserRole == TripBoardRole.OWNER) {
+                    Long newOwnerId = transferOwnership(tripBoardId, userId);
+                    log.info("OWNER 권한 이양 완료 - 이전 OWNER: {}, 새 OWNER: {}", userId, newOwnerId);
+                }
+
+                // 7. 리소스 처리 (removeResources가 true인 경우)
+                if (removeResources) {
+                    deleteUserResources(tripBoardId, userId);
+                    log.info("사용자 리소스 삭제 완료 - 사용자 ID: {}", userId);
+                }
+
+                // 8. 사용자-여행보드 매핑 삭제
+                userTripBoardRepository.deleteByUserIdAndTripBoardId(userId, tripBoardId);
+                log.debug("사용자-여행보드 매핑 삭제 완료 - 사용자 ID: {}, 보드 ID: {}", userId, tripBoardId);
+
+                String message = currentUserRole == TripBoardRole.OWNER
+                        ? "여행보드에서 성공적으로 나갔습니다. 소유자 권한이 이양되었습니다."
+                        : "여행보드에서 성공적으로 나갔습니다.";
+            }
+
+            // 9. 응답 객체 반환
+            log.info("여행보드 나가기 완료 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId);
+            return tripBoardLeaveResponse;
+
+        } catch (TripBoardNotFoundException | UserAuthorizationException e) {
+            log.error("여행보드 나가기 실패 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId, e);
+            throw e;
+        } catch (DataAccessException e) {
+            log.error("여행보드 나가기 중 데이터베이스 오류 발생 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId, e);
+            throw new TripBoardLeaveException();
+        } catch (Exception e) {
+            log.error("여행보드 나가기 중 예상치 못한 오류 발생 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId, e);
+            throw new TripBoardLeaveException();
+        }
+    }
+
+    /**
+     * OWNER 권한을 다음 MEMBER에게 이양합니다.
+     * 가장 먼저 입장한 MEMBER를 찾아 OWNER로 변경합니다.
+     */
+    private Long transferOwnership(Long tripBoardId, Long currentOwnerId) {
+        log.debug("OWNER 권한 이양 시작 - 보드 ID: {}, 현재 OWNER: {}", tripBoardId, currentOwnerId);
+
+        // 가장 먼저 입장한 MEMBER 조회
+        List<UserTripBoardEntity> members = userTripBoardRepository
+                .findByTripBoardIdAndRoleOrderByCreatedAtAsc(tripBoardId, TripBoardRole.MEMBER);
+
+        if (members.isEmpty()) {
+            log.error("OWNER 권한 이양 실패 - 다음 MEMBER가 없음: 보드 ID: {}", tripBoardId);
+            throw new TripBoardLeaveException();
+        }
+
+        // 첫 번째 MEMBER를 OWNER로 변경
+        UserTripBoardEntity nextOwner = members.get(0);
+        UserTripBoardEntity updatedNextOwner = UserTripBoardEntity.builder()
+                .id(nextOwner.getId())
+                .user(nextOwner.getUser())
+                .tripBoard(nextOwner.getTripBoard())
+                .invitationUrl(nextOwner.getInvitationUrl())
+                .invitationActive(nextOwner.getInvitationActive())
+                .role(TripBoardRole.OWNER)
+                .createdAt(nextOwner.getCreatedAt())
+                .build();
+
+        userTripBoardRepository.save(updatedNextOwner);
+
+        Long newOwnerId = nextOwner.getUser().getId();
+        log.debug("OWNER 권한 이양 완료 - 새 OWNER: {}", newOwnerId);
+        return newOwnerId;
+    }
+
+    /**
+     * 사용자가 생성한 리소스(비교표, 숙소)를 삭제합니다.
+     */
+    private void deleteUserResources(Long tripBoardId, Long userId) {
+        log.debug("사용자 리소스 삭제 시작 - 보드 ID: {}, 사용자 ID: {}", tripBoardId, userId);
+
+        // 사용자가 생성한 비교표 삭제
+        comparisonTableRepository.deleteByTripBoardIdAndCreatedById(tripBoardId, userId);
+        log.debug("사용자 비교표 삭제 완료 - 사용자 ID: {}", userId);
+
+        // 사용자가 등록한 숙소 삭제
+        accommodationRepository.deleteByBoardIdAndCreatedById(tripBoardId, userId);
+        log.debug("사용자 숙소 삭제 완료 - 사용자 ID: {}", userId);
+    }
+
+    /**
+     * 여행보드를 완전히 삭제합니다.
+     * 관련된 모든 데이터(비교표, 숙소, 사용자 매핑)를 함께 삭제합니다.
+     */
+    private void deleteTripBoardCompletely(Long tripBoardId) {
+        log.debug("여행보드 완전 삭제 시작 - 보드 ID: {}", tripBoardId);
+
+        // 1. 비교표 삭제 (ComparisonAccommodation 매핑도 CASCADE로 함께 삭제됨)
+        jpaComparisonTableRepository.deleteByTripBoardId(tripBoardId);
+        log.debug("비교표 삭제 완료 - 보드 ID: {}", tripBoardId);
+
+        // 2. 숙소 삭제
+        jpaAccommodationRepository.deleteByBoardId(tripBoardId);
+        log.debug("숙소 삭제 완료 - 보드 ID: {}", tripBoardId);
+
+        // 3. 사용자-여행보드 매핑 삭제
+        userTripBoardRepository.deleteByTripBoardId(tripBoardId);
+        log.debug("사용자-여행보드 매핑 삭제 완료 - 보드 ID: {}", tripBoardId);
+
+        // 4. 여행보드 삭제
+        jpaTripBoardRepository.deleteById(tripBoardId);
+        log.debug("여행보드 삭제 완료 - 보드 ID: {}", tripBoardId);
     }
 
 }

--- a/src/main/java/com/yapp/backend/service/impl/TripBoardServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/TripBoardServiceImpl.java
@@ -368,6 +368,7 @@ public class TripBoardServiceImpl implements TripBoardService {
     /**
      * 여행보드 나가기
      * OWNER가 나가는 경우 다음 MEMBER에게 권한을 이양하고, 마지막 참여자인 경우 여행보드를 완전 삭제합니다.
+     * todo 치명적: 마지막 두 명이 동시에 나가면 ‘참여자 0명 보드’가 남을 수 있음 + removeResources NPE 위험
      */
     @Override
     @Transactional
@@ -421,7 +422,7 @@ public class TripBoardServiceImpl implements TripBoardService {
                 }
 
                 // 7. 리소스 처리 (removeResources가 true인 경우)
-                if (removeResources) {
+                if (Boolean.TRUE.equals(removeResources)) {
                     deleteUserResources(tripBoardId, userId);
                     log.info("사용자 리소스 삭제 완료 - 사용자 ID: {}", userId);
                 }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
여행보드 나가기 API 구현

### PR 체크리스트
- [X] 정상적으로 실행이 되나요?
- [X] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [X] 컨벤션 규칙을 지켰나요?
- [X] merge branch 를 확인했나요?


### 추가 전달 사항
여행보드 나가기 API 구현
AOP 결합 이후, PR rebase 필

### 테스트 결과
<img width="1134" height="617" alt="image" src="https://github.com/user-attachments/assets/6822ad1c-1962-49a0-85da-9b3e13587bab" />



-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 여행보드에서 나가기 기능이 추가되었습니다. 사용자는 여행보드에서 나갈 때 본인이 생성한 비교표와 숙소 리소스를 함께 삭제할지 선택할 수 있습니다.
  * 만약 마지막 참가자가 나갈 경우 여행보드가 완전히 삭제되며, 소유자가 나갈 경우 가장 먼저 가입한 멤버에게 소유권이 이전됩니다.
* **버그 수정**
  * 여행보드 나가기 실패 시 적절한 에러 메시지가 제공됩니다.
* **문서화**
  * 여행보드 나가기 API 엔드포인트 및 동작 방식이 문서에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->