### PR TITLE
[Y26W2-257] fix: access, refresh token 응답 객체로 전달

### DIFF
--- a/src/main/java/com/yapp/backend/controller/OauthController.java
+++ b/src/main/java/com/yapp/backend/controller/OauthController.java
@@ -81,13 +81,9 @@ public class OauthController implements OauthDocs {
         
         // 3. Redis에 Refresh Token 저장
         refreshTokenService.storeRefresh(oauthResponse.getUserId(), refreshToken);
-        
-        // 4. HTTP 응답에 토큰 설정 (Access Token은 헤더, Refresh Token은 쿠키)
-        response.setHeader(ACCESS_TOKEN_HEADER, accessToken);
-        ResponseCookie refreshCookie = jwtTokenProvider.generateRefreshTokenCookie(oauthResponse.getUserId());
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
-        
-        // 5. 사용자 정보만 응답 바디로 반환 (토큰은 헤더로 전달됨)
+
+        // 4. 사용자 정보만 응답 바디로 반환 (토큰은 헤더로 전달됨)
+        oauthResponse.deliverToken(accessToken, refreshToken);
         return ResponseEntity.ok(new StandardResponse<>(SUCCESS, oauthResponse));
     }
 

--- a/src/main/java/com/yapp/backend/controller/dto/response/OauthLoginResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/OauthLoginResponse.java
@@ -10,4 +10,14 @@ import lombok.Getter;
 public class OauthLoginResponse {
         private Long userId;
         private String nickname;
+        private TokenSuccessResponse token;
+
+        public OauthLoginResponse(Long userId, String nickname) {
+                this.userId = userId;
+                this.nickname = nickname;
+        }
+
+        public void deliverToken(String accessToken, String refreshToken) {
+                this.token = new TokenSuccessResponse(accessToken, refreshToken);
+        }
 }

--- a/src/main/java/com/yapp/backend/controller/dto/response/TokenSuccessResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/TokenSuccessResponse.java
@@ -1,0 +1,11 @@
+package com.yapp.backend.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenSuccessResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -68,7 +68,6 @@ public class JwtFilter extends OncePerRequestFilter {
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token is blacklisted");
                 return;
             }
-            
             authContextService.createAuthContext(accessToken);
             filterChain.doFilter(request, response);
         } catch (JwtException | IllegalArgumentException bad) {
@@ -111,12 +110,7 @@ public class JwtFilter extends OncePerRequestFilter {
         // 2) Redis Refresh Token 회전
         refreshTokenService.rotateRefresh(userId, newRefresh);
 
-        // 3) 새로운 토큰 설정 (Access Token은 헤더, Refresh Token은 쿠키)
-        response.setHeader(ACCESS_TOKEN_HEADER, newAccess);
-        ResponseCookie refreshCookie = jwtTokenProvider.generateRefreshTokenCookie(userId);
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
-
-        // 4) 인증 객체 세팅
+        // 3) 인증 객체 세팅
         authContextService.createAuthContext(newAccess);
     }
 }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 액세스 토큰, 레프레시 토큰을 응답 객체 전달로 변경

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [ ] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과
<img width="302" height="219" alt="image" src="https://github.com/user-attachments/assets/1ac59707-51e7-4297-8ba1-e3b521f1749b" />

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 토큰 정보를 응답 본문 내 별도 객체로 제공하도록 개선되었습니다.

* **버그 수정**
  * 토큰이 더 이상 응답 헤더나 쿠키로 전달되지 않고, 응답 객체를 통해 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->