### PR TITLE
[Y26W2-229] 숙소리스트 조회 API 응답 유저 메타데이터 추가

### DIFF
--- a/src/main/java/com/yapp/backend/controller/AccommodationController.java
+++ b/src/main/java/com/yapp/backend/controller/AccommodationController.java
@@ -10,6 +10,7 @@ import com.yapp.backend.controller.dto.response.AccommodationRegisterResponse;
 import com.yapp.backend.controller.dto.response.AccommodationResponse;
 import com.yapp.backend.filter.dto.CustomUserDetails;
 import com.yapp.backend.service.AccommodationService;
+import com.yapp.backend.service.TripBoardService;
 import com.yapp.backend.service.UserTripBoardAuthorizationService;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/yapp/backend/controller/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/UserProfileResponse.java
@@ -5,14 +5,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class AccommodationPageResponse {
-    private List<AccommodationResponse> accommodations;
-    private List<UserProfileResponse> userProfiles;
-    private boolean hasNext;
+public class UserProfileResponse {
+    private Long userId;
+    private String nickname;
 }

--- a/src/main/java/com/yapp/backend/repository/JpaUserTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaUserTripBoardRepository.java
@@ -60,6 +60,14 @@ public interface JpaUserTripBoardRepository extends JpaRepository<UserTripBoardE
     List<UserTripBoardEntity> findByTripBoardIdsWithUser(@Param("tripBoardIds") List<Long> tripBoardIds);
 
     /**
+     * 특정 여행보드의 모든 참여자를 사용자 정보와 함께 조회
+     */
+    @Query("SELECT utb FROM UserTripBoardEntity utb " +
+            "JOIN FETCH utb.user u " +
+            "WHERE utb.tripBoard.id = :tripBoardId")
+    List<UserTripBoardEntity> findByTripBoardIdWithUser(@Param("tripBoardId") Long tripBoardId);
+
+    /**
      * 여행보드의 특정 역할 참여자를 생성일 오름차순으로 조회 (다음 OWNER 후보 조회용)
      */
     List<UserTripBoardEntity> findByTripBoardIdAndRoleOrderByCreatedAtAsc(Long tripBoardId, TripBoardRole role);

--- a/src/main/java/com/yapp/backend/repository/UserTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/UserTripBoardRepository.java
@@ -40,4 +40,9 @@ public interface UserTripBoardRepository {
      * 사용자-여행보드 매핑 정보 저장/업데이트
      */
     UserTripBoard save(UserTripBoard userTripBoard);
+
+    /**
+     * 특정 여행보드의 모든 참여자를 사용자 정보와 함께 조회
+     */
+    List<UserTripBoard> findByTripBoardIdWithUser(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/impl/UserTripBoardRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/UserTripBoardRepositoryImpl.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * 사용자-여행보드 매핑 Repository 구현체
@@ -57,5 +56,13 @@ public class UserTripBoardRepositoryImpl implements UserTripBoardRepository {
         UserTripBoardEntity entity = userTripBoardMapper.domainToEntity(userTripBoard);
         UserTripBoardEntity savedEntity = jpaUserTripBoardRepository.save(entity);
         return userTripBoardMapper.entityToDomain(savedEntity);
+    }
+
+    @Override
+    public List<UserTripBoard> findByTripBoardIdWithUser(Long tripBoardId) {
+        return jpaUserTripBoardRepository.findByTripBoardIdWithUser(tripBoardId)
+                .stream()
+                .map(userTripBoardMapper::entityToDomain)
+                .toList();
     }
 }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
숙소리스트 조회 API에 유저 메타데이터 추가

### PR 체크리스트
- [X] 정상적으로 실행이 되나요?
- [X] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [X] 컨벤션 규칙을 지켰나요?
- [X] merge branch 를 확인했나요?

### 추가 전달 사항
없습니다.

### 테스트 결과
<img width="697" height="835" alt="image" src="https://github.com/user-attachments/assets/d0a6db8a-53fe-41e6-bc3c-85e1529b1c38" />


-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 여행 보드의 숙소 목록 조회 시, 해당 보드 참가자들의 사용자 프로필 정보(사용자 ID 및 닉네임)가 함께 제공됩니다.

* **버그 수정**
  * 사용자 프로필 정보가 정상적으로 조회되지 않을 경우에도 숙소 데이터는 계속 반환되며, 관련 오류는 내부적으로 로깅됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->