### PR TITLE
[Y26W2-297] 리프레시 토큰 재발급 API

### DIFF
--- a/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰", "리프레시 토큰이 유효하지 않거나 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_REFRESH_TOKEN("만료된 리프레시 토큰", "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요.", HttpStatus.UNAUTHORIZED),
     TOKEN_GENERATION_FAILED("토큰 생성 실패", "토큰 생성 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    REDIS_OPERATION_FAILED("Redis 작업 실패", "Redis 저장소 작업 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // Accommodation related errors
     INVALID_TABLE_ID("잘못된 테이블 ID", "존재하지 않거나 유효하지 않은 테이블 ID입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
@@ -21,6 +21,10 @@ public enum ErrorCode {
     AUTHENTICATION_CREDENTIALS_NOT_FOUND("인증 정보 누락", "인증 정보가 필요합니다.", HttpStatus.UNAUTHORIZED),
     ACCESS_DENIED("접근 권한 부족", "접근 권한이 부족합니다.", HttpStatus.FORBIDDEN),
     AUTHENTICATION_SERVICE_ERROR("인증 서비스 오류", "인증 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    
+    // Token related errors
+    INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰", "리프레시 토큰이 유효하지 않거나 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    EXPIRED_REFRESH_TOKEN("만료된 리프레시 토큰", "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요.", HttpStatus.UNAUTHORIZED),
 
     // Accommodation related errors
     INVALID_TABLE_ID("잘못된 테이블 ID", "존재하지 않거나 유효하지 않은 테이블 ID입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     // Token related errors
     INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰", "리프레시 토큰이 유효하지 않거나 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_REFRESH_TOKEN("만료된 리프레시 토큰", "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요.", HttpStatus.UNAUTHORIZED),
+    TOKEN_GENERATION_FAILED("토큰 생성 실패", "토큰 생성 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // Accommodation related errors
     INVALID_TABLE_ID("잘못된 테이블 ID", "존재하지 않거나 유효하지 않은 테이블 ID입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/yapp/backend/common/exception/ExpiredRefreshTokenException.java
+++ b/src/main/java/com/yapp/backend/common/exception/ExpiredRefreshTokenException.java
@@ -1,0 +1,34 @@
+package com.yapp.backend.common.exception;
+
+/**
+ * 만료된 리프레시 토큰에 대한 예외
+ * Redis에 저장된 토큰과 일치하지 않거나 만료된 경우 발생
+ */
+public class ExpiredRefreshTokenException extends CustomException {
+
+    public ExpiredRefreshTokenException() {
+        super(ErrorCode.EXPIRED_REFRESH_TOKEN);
+    }
+
+    public ExpiredRefreshTokenException(String message) {
+        super(ErrorCode.EXPIRED_REFRESH_TOKEN, message);
+    }
+
+    public ExpiredRefreshTokenException(Throwable cause) {
+        super(ErrorCode.EXPIRED_REFRESH_TOKEN, cause);
+    }
+
+    public ExpiredRefreshTokenException(String message, Throwable cause) {
+        super(ErrorCode.EXPIRED_REFRESH_TOKEN, message, cause);
+    }
+
+    /**
+     * 사용자 ID를 포함한 상세 메시지로 예외 생성
+     * 
+     * @param userId 사용자 ID
+     */
+    public ExpiredRefreshTokenException(Long userId) {
+        super(ErrorCode.EXPIRED_REFRESH_TOKEN, 
+              String.format("사용자 %d의 리프레시 토큰이 만료되었거나 유효하지 않습니다", userId));
+    }
+}

--- a/src/main/java/com/yapp/backend/common/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/yapp/backend/common/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,24 @@
+package com.yapp.backend.common.exception;
+
+/**
+ * 유효하지 않은 리프레시 토큰에 대한 예외
+ * 토큰 형식이 잘못되었거나 파싱할 수 없는 경우 발생
+ */
+public class InvalidRefreshTokenException extends CustomException {
+
+    public InvalidRefreshTokenException() {
+        super(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    public InvalidRefreshTokenException(String message) {
+        super(ErrorCode.INVALID_REFRESH_TOKEN, message);
+    }
+
+    public InvalidRefreshTokenException(Throwable cause) {
+        super(ErrorCode.INVALID_REFRESH_TOKEN, cause);
+    }
+
+    public InvalidRefreshTokenException(String message, Throwable cause) {
+        super(ErrorCode.INVALID_REFRESH_TOKEN, message, cause);
+    }
+}

--- a/src/main/java/com/yapp/backend/common/exception/RedisOperationException.java
+++ b/src/main/java/com/yapp/backend/common/exception/RedisOperationException.java
@@ -1,0 +1,25 @@
+package com.yapp.backend.common.exception;
+
+/**
+ * Redis 연산 실패 시 발생하는 예외
+ */
+public class RedisOperationException extends CustomException {
+    
+    public RedisOperationException(String message) {
+        super(ErrorCode.REDIS_OPERATION_FAILED, message);
+    }
+    
+    public RedisOperationException(String message, Throwable cause) {
+        super(ErrorCode.REDIS_OPERATION_FAILED, message, cause);
+    }
+    
+    public RedisOperationException(String operation, Long userId) {
+        super(ErrorCode.REDIS_OPERATION_FAILED, 
+              String.format("Redis %s 작업이 실패했습니다. userId: %d", operation, userId));
+    }
+    
+    public RedisOperationException(String operation, Long userId, Throwable cause) {
+        super(ErrorCode.REDIS_OPERATION_FAILED, 
+              String.format("Redis %s 작업이 실패했습니다. userId: %d", operation, userId), cause);
+    }
+}

--- a/src/main/java/com/yapp/backend/common/exception/TokenGenerationException.java
+++ b/src/main/java/com/yapp/backend/common/exception/TokenGenerationException.java
@@ -1,0 +1,25 @@
+package com.yapp.backend.common.exception;
+
+/**
+ * 토큰 생성 과정에서 발생하는 예외
+ */
+public class TokenGenerationException extends CustomException {
+    
+    public TokenGenerationException(String message) {
+        super(ErrorCode.TOKEN_GENERATION_FAILED, message);
+    }
+    
+    public TokenGenerationException(String message, Throwable cause) {
+        super(ErrorCode.TOKEN_GENERATION_FAILED, message, cause);
+    }
+    
+    public TokenGenerationException(Long userId) {
+        super(ErrorCode.TOKEN_GENERATION_FAILED, 
+              String.format("사용자 %d의 토큰 생성에 실패했습니다.", userId));
+    }
+    
+    public TokenGenerationException(Long userId, Throwable cause) {
+        super(ErrorCode.TOKEN_GENERATION_FAILED, 
+              String.format("사용자 %d의 토큰 생성에 실패했습니다.", userId), cause);
+    }
+}

--- a/src/main/java/com/yapp/backend/common/util/JwtTokenProvider.java
+++ b/src/main/java/com/yapp/backend/common/util/JwtTokenProvider.java
@@ -69,12 +69,12 @@ public class JwtTokenProvider {
         try {
             Date now = new Date();
             Date expiration = new Date(now.getTime() + accessTokenValidityInMs);
-            
+
             String token = Jwts.builder()
-                    .setSubject(String.valueOf(userId))
-                    .setIssuedAt(now)
-                    .setExpiration(expiration)
-                    .signWith(accessSecretKey, SignatureAlgorithm.HS256)
+                    .subject(String.valueOf(userId))
+                    .issuedAt(now)
+                    .expiration(expiration)
+                    .signWith(accessSecretKey, Jwts.SIG.HS256)
                     .compact();
                     
             log.debug("Access token 생성 완료. userId: {}", userId);
@@ -102,12 +102,12 @@ public class JwtTokenProvider {
             Date expiration = new Date(now.getTime() + refreshTokenValidityInMs);
             
             String token = Jwts.builder()
-                    .setSubject(String.valueOf(userId))
-                    .setIssuedAt(now)
-                    .setExpiration(expiration)
-                    .signWith(refreshSecretKey, SignatureAlgorithm.HS256)
+                    .subject(String.valueOf(userId))
+                    .issuedAt(now)
+                    .expiration(expiration)
+                    .signWith(refreshSecretKey, Jwts.SIG.HS256)
                     .compact();
-                    
+
             log.debug("Refresh token 생성 완료. userId: {}", userId);
             return token;
             

--- a/src/main/java/com/yapp/backend/common/util/JwtTokenProvider.java
+++ b/src/main/java/com/yapp/backend/common/util/JwtTokenProvider.java
@@ -130,7 +130,7 @@ public class JwtTokenProvider {
         long maxAgeInSeconds = refreshTokenValidityInMs / MILLISECONDS_PER_SECOND;
         
         // Redis에 Refresh Token 저장
-        refreshTokenService.storeRefresh(userId, refreshToken);
+        refreshTokenService.storeRefreshOrThrow(userId, refreshToken);
         
         return ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
                 .httpOnly(true)

--- a/src/main/java/com/yapp/backend/common/util/JwtTokenProvider.java
+++ b/src/main/java/com/yapp/backend/common/util/JwtTokenProvider.java
@@ -7,6 +7,7 @@ import com.yapp.backend.filter.service.RefreshTokenService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import com.yapp.backend.common.exception.TokenGenerationException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
@@ -59,18 +60,30 @@ public class JwtTokenProvider {
      *
      * @param userId 사용자 ID
      * @return JWT Access Token
+     * @throws IllegalArgumentException 사용자 ID가 유효하지 않은 경우
+     * @throws TokenGenerationException 토큰 생성 실패 시
      */
     public String createAccessToken(Long userId) {
         validateUserId(userId);
-        Date now = new Date();
-        Date expiration = new Date(now.getTime() + accessTokenValidityInMs);
         
-        return Jwts.builder()
-                .setSubject(String.valueOf(userId))
-                .setIssuedAt(now)
-                .setExpiration(expiration)
-                .signWith(accessSecretKey, SignatureAlgorithm.HS256)
-                .compact();
+        try {
+            Date now = new Date();
+            Date expiration = new Date(now.getTime() + accessTokenValidityInMs);
+            
+            String token = Jwts.builder()
+                    .setSubject(String.valueOf(userId))
+                    .setIssuedAt(now)
+                    .setExpiration(expiration)
+                    .signWith(accessSecretKey, SignatureAlgorithm.HS256)
+                    .compact();
+                    
+            log.debug("Access token 생성 완료. userId: {}", userId);
+            return token;
+            
+        } catch (Exception e) {
+            log.error("Access token 생성 실패. userId: {}, error: {}", userId, e.getMessage(), e);
+            throw new TokenGenerationException(userId, e);
+        }
     }
 
     /**
@@ -78,18 +91,30 @@ public class JwtTokenProvider {
      *
      * @param userId 사용자 ID
      * @return JWT Refresh Token
+     * @throws IllegalArgumentException 사용자 ID가 유효하지 않은 경우
+     * @throws TokenGenerationException 토큰 생성 실패 시
      */
     public String createRefreshToken(Long userId) {
         validateUserId(userId);
-        Date now = new Date();
-        Date expiration = new Date(now.getTime() + refreshTokenValidityInMs);
         
-        return Jwts.builder()
-                .setSubject(String.valueOf(userId))
-                .setIssuedAt(now)
-                .setExpiration(expiration)
-                .signWith(refreshSecretKey, SignatureAlgorithm.HS256)
-                .compact();
+        try {
+            Date now = new Date();
+            Date expiration = new Date(now.getTime() + refreshTokenValidityInMs);
+            
+            String token = Jwts.builder()
+                    .setSubject(String.valueOf(userId))
+                    .setIssuedAt(now)
+                    .setExpiration(expiration)
+                    .signWith(refreshSecretKey, SignatureAlgorithm.HS256)
+                    .compact();
+                    
+            log.debug("Refresh token 생성 완료. userId: {}", userId);
+            return token;
+            
+        } catch (Exception e) {
+            log.error("Refresh token 생성 실패. userId: {}, error: {}", userId, e.getMessage(), e);
+            throw new TokenGenerationException(userId, e);
+        }
     }
 
     // ==================== 쿠키 생성 메서드 ====================

--- a/src/main/java/com/yapp/backend/controller/OauthController.java
+++ b/src/main/java/com/yapp/backend/controller/OauthController.java
@@ -113,6 +113,7 @@ public class OauthController implements OauthDocs {
     /**
      * 리프레시 토큰 재발급 API
      * 유효한 리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.
+     * 액세스 토큰이 만료된 상황에서 사용되므로 JWT 인증이 필요하지 않습니다.
      *
      * @param request 리프레시 토큰 재발급 요청
      * @return 새로 발급된 토큰 정보

--- a/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
@@ -1,9 +1,11 @@
 package com.yapp.backend.controller.docs;
 
 import com.yapp.backend.common.response.StandardResponse;
+import com.yapp.backend.controller.dto.request.RefreshTokenRequest;
 import com.yapp.backend.controller.dto.response.AuthorizeUrlResponse;
 import com.yapp.backend.controller.dto.response.LogoutResponse;
 import com.yapp.backend.controller.dto.response.OauthLoginResponse;
+import com.yapp.backend.controller.dto.response.TokenSuccessResponse;
 import com.yapp.backend.controller.dto.response.WithdrawResponse;
 import com.yapp.backend.filter.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +18,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "OAUTH API", description = "소셜 로그인 API")
@@ -68,6 +71,25 @@ public interface OauthDocs {
             @Parameter(hidden = true) HttpServletRequest request,
             @Parameter(hidden = true) HttpServletResponse response
     );
+
+    @Operation(
+            summary = "리프레시 토큰 재발급",
+            description = "유효한 리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다. " +
+                         "기존 리프레시 토큰은 무효화되고 새로운 토큰 쌍이 생성됩니다. " +
+                         "토큰 회전(Token Rotation)을 통해 보안을 강화합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "새로운 토큰이 성공적으로 발급되었습니다."
+    )
+    @ApiResponse(
+            responseCode = "401",
+            description = "리프레시 토큰이 유효하지 않거나 만료되었습니다."
+    )
+    ResponseEntity<StandardResponse<TokenSuccessResponse>> refreshTokens(
+            @RequestBody RefreshTokenRequest request
+    );
+
     @Operation(
             summary = "사용자 회원탈퇴",
             description = ""

--- a/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/OauthDocs.java
@@ -76,7 +76,8 @@ public interface OauthDocs {
             summary = "리프레시 토큰 재발급",
             description = "유효한 리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다. " +
                          "기존 리프레시 토큰은 무효화되고 새로운 토큰 쌍이 생성됩니다. " +
-                         "토큰 회전(Token Rotation)을 통해 보안을 강화합니다."
+                         "토큰 회전(Token Rotation)을 통해 보안을 강화합니다. " +
+                         "이 API는 액세스 토큰이 만료된 상황에서 사용되므로 JWT 인증이 필요하지 않습니다."
     )
     @ApiResponse(
             responseCode = "200",

--- a/src/main/java/com/yapp/backend/controller/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/yapp/backend/controller/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,18 @@
+package com.yapp.backend.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "리프레시 토큰 재발급 요청")
+public class RefreshTokenRequest {
+
+    @NotBlank(message = "리프레시 토큰은 필수입니다")
+    @Schema(description = "리프레시 토큰")
+    private String refreshToken;
+}

--- a/src/main/java/com/yapp/backend/controller/dto/response/OauthLoginResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/OauthLoginResponse.java
@@ -8,8 +8,14 @@ import lombok.Getter;
 @AllArgsConstructor
 @Schema(description = "OAuth 로그인 응답")
 public class OauthLoginResponse {
+        
+        @Schema(description = "사용자 ID", example = "12345")
         private Long userId;
+        
+        @Schema(description = "사용자 닉네임", example = "홍길동")
         private String nickname;
+        
+        @Schema(description = "토큰 정보")
         private TokenSuccessResponse token;
 
         public OauthLoginResponse(Long userId, String nickname) {

--- a/src/main/java/com/yapp/backend/controller/dto/response/TokenSuccessResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/TokenSuccessResponse.java
@@ -1,11 +1,17 @@
 package com.yapp.backend.controller.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "토큰 발급 응답")
 public class TokenSuccessResponse {
+    
+    @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSIsImlhdCI6MTcwMDAwMDAwMCwiZXhwIjoxNzAwMDAzNjAwfQ.example-access-token-signature")
     private String accessToken;
+    
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSIsImlhdCI6MTcwMDAwMDAwMCwiZXhwIjoxNzAyNTkyMDAwfQ.example-refresh-token-signature")
     private String refreshToken;
 }

--- a/src/main/java/com/yapp/backend/controller/dto/response/TokenSuccessResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/TokenSuccessResponse.java
@@ -9,9 +9,9 @@ import lombok.Getter;
 @Schema(description = "토큰 발급 응답")
 public class TokenSuccessResponse {
     
-    @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSIsImlhdCI6MTcwMDAwMDAwMCwiZXhwIjoxNzAwMDAzNjAwfQ.example-access-token-signature")
+    @Schema(description = "액세스 토큰", accessMode = Schema.AccessMode.READ_ONLY, example = "access-token-example")
     private String accessToken;
     
-    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NSIsImlhdCI6MTcwMDAwMDAwMCwiZXhwIjoxNzAyNTkyMDAwfQ.example-refresh-token-signature")
+    @Schema(description = "리프레시 토큰", accessMode = Schema.AccessMode.READ_ONLY, example = "refresh-token-example")
     private String refreshToken;
 }

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -47,6 +47,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 || uri.startsWith("/api/comparison/factors")
                 || uri.startsWith("/api/comparison/amenity")
                 || uri.startsWith("/api/oauth/kakao")
+                || uri.startsWith("/api/oauth/refresh")
                 ;
     }
 

--- a/src/main/java/com/yapp/backend/service/OauthService.java
+++ b/src/main/java/com/yapp/backend/service/OauthService.java
@@ -1,6 +1,9 @@
 package com.yapp.backend.service;
 
+import com.yapp.backend.common.exception.ExpiredRefreshTokenException;
+import com.yapp.backend.common.exception.InvalidRefreshTokenException;
 import com.yapp.backend.controller.dto.response.OauthLoginResponse;
+import com.yapp.backend.controller.dto.response.TokenSuccessResponse;
 
 public interface OauthService {
     
@@ -15,16 +18,24 @@ public interface OauthService {
     
     /**
      * 지정된 OAuth 공급자의 인가 코드를 통해 토큰을 교환하고 사용자 정보를 조회하여 JWT를 발급합니다.
+     * 토큰 생성, Redis 저장, 사용자 정보 조회를 일괄 처리합니다.
      * 
      * @param provider OAuth 공급자 (kakao, google, naver 등)
      * @param code OAuth 공급자에서 발급받은 인가 코드
      * @param baseUrl 클라이언트의 베이스 URL (토큰 교환 시 redirect_uri 생성용)
-     * @return JWT 토큰 응답
+     * @return 사용자 정보와 토큰 정보를 포함한 응답
      */
     OauthLoginResponse exchangeCodeForToken(String provider, String code, String baseUrl);
 
     /**
-     * 토큰 정보를 담는 레코드
+     * 리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.
+     * 기존 리프레시 토큰은 무효화되고 새로운 토큰 쌍이 생성됩니다.
+     * 토큰 회전(Token Rotation) 정책을 통해 보안을 강화합니다.
+     * 
+     * @param refreshToken 유효한 리프레시 토큰
+     * @return 새로 발급된 액세스 토큰과 리프레시 토큰
+     * @throws InvalidRefreshTokenException 리프레시 토큰이 유효하지 않거나 파싱할 수 없는 경우
+     * @throws ExpiredRefreshTokenException 리프레시 토큰이 만료되었거나 Redis에 저장된 토큰과 일치하지 않는 경우
      */
-    record TokenInfo(String accessToken, String refreshToken) {}
+    TokenSuccessResponse refreshTokens(String refreshToken);
 }

--- a/src/main/java/com/yapp/backend/service/impl/OauthServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/OauthServiceImpl.java
@@ -170,9 +170,11 @@ public class OauthServiceImpl implements OauthService {
             throw new ExpiredRefreshTokenException(userId);
         }
 
-        // 4. 새로운 액세스 토큰과 리프레시 토큰 생성
+        // 4. 새로운 액세스 토큰과 리프레시 토큰 생성 (JwtTokenProvider에서 예외 처리됨)
         String newAccessToken = jwtTokenProvider.createAccessToken(userId);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+        
+        log.debug("리프레시 토큰 재발급을 위한 새 토큰 생성 완료. userId: {}", userId);
 
         // 5. Redis에서 리프레시 토큰 회전 (기존 토큰 무효화 및 새 토큰 저장)
         refreshTokenService.rotateRefresh(userId, newRefreshToken);

--- a/src/main/java/com/yapp/backend/service/impl/OauthServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/OauthServiceImpl.java
@@ -74,8 +74,8 @@ public class OauthServiceImpl implements OauthService {
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
-        // 5. Redis에 Refresh Token 저장
-        refreshTokenService.storeRefresh(user.getId(), refreshToken);
+        // 5. Redis에 Refresh Token 저장 (RefreshTokenService에서 예외 처리)
+        refreshTokenService.storeRefreshOrThrow(user.getId(), refreshToken);
 
         // 6. 토큰 정보를 포함한 응답 생성
         OauthLoginResponse response = new OauthLoginResponse(
@@ -176,7 +176,7 @@ public class OauthServiceImpl implements OauthService {
         
         log.debug("리프레시 토큰 재발급을 위한 새 토큰 생성 완료. userId: {}", userId);
 
-        // 5. Redis에서 리프레시 토큰 회전 (기존 토큰 무효화 및 새 토큰 저장)
+        // 5. Redis에서 리프레시 토큰 회전 (RefreshTokenService에서 예외 처리됨)
         refreshTokenService.rotateRefresh(userId, newRefreshToken);
 
         log.info("리프레시 토큰 재발급 완료. userId: {}", userId);

--- a/src/main/java/com/yapp/backend/service/impl/OauthServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/OauthServiceImpl.java
@@ -3,13 +3,18 @@ package com.yapp.backend.service.impl;
 import com.yapp.backend.common.util.JwtTokenProvider;
 import com.yapp.backend.config.OAuthSecurityProperties;
 import com.yapp.backend.controller.dto.response.OauthLoginResponse;
+import com.yapp.backend.controller.dto.response.TokenSuccessResponse;
 import com.yapp.backend.filter.dto.SocialUserInfo;
+import com.yapp.backend.filter.service.RefreshTokenService;
 import com.yapp.backend.service.OauthService;
 import com.yapp.backend.service.UserLoginService;
 import com.yapp.backend.service.model.User;
 import com.yapp.backend.service.oauth.OAuthCodeUserInfoProvider;
 import com.yapp.backend.common.exception.oauth.InvalidBaseUrlException;
 import com.yapp.backend.common.exception.oauth.UnsupportedOAuthProviderException;
+import com.yapp.backend.common.exception.InvalidRefreshTokenException;
+import com.yapp.backend.common.exception.ExpiredRefreshTokenException;
+import io.jsonwebtoken.Claims;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -23,6 +28,7 @@ public class OauthServiceImpl implements OauthService {
     
     private final UserLoginService userLoginService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
     private final OAuthSecurityProperties oauthSecurityProperties;
     private final Map<String, OAuthCodeUserInfoProvider> providers;
     
@@ -30,6 +36,7 @@ public class OauthServiceImpl implements OauthService {
             List<OAuthCodeUserInfoProvider> providerList,
             UserLoginService userLoginService,
             JwtTokenProvider jwtTokenProvider,
+            RefreshTokenService refreshTokenService,
             OAuthSecurityProperties oauthSecurityProperties
     ) {
         // Spring이 빈 이름 기준으로 자동 주입
@@ -37,6 +44,7 @@ public class OauthServiceImpl implements OauthService {
                 .collect(Collectors.toMap(OAuthCodeUserInfoProvider::getProviderKey, p -> p));
         this.userLoginService = userLoginService;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenService = refreshTokenService;
         this.oauthSecurityProperties = oauthSecurityProperties;
     }
     
@@ -62,11 +70,22 @@ public class OauthServiceImpl implements OauthService {
         // 3. 사용자 저장 또는 조회
         User user = userLoginService.handleOAuthLogin(socialUser);
 
-        // 4. 사용자 정보로 응답 생성 (토큰은 컨트롤러에서 쿠키로 설정)
-        return new OauthLoginResponse(
+        // 4. 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+        // 5. Redis에 Refresh Token 저장
+        refreshTokenService.storeRefresh(user.getId(), refreshToken);
+
+        // 6. 토큰 정보를 포함한 응답 생성
+        OauthLoginResponse response = new OauthLoginResponse(
                 user.getId(),
                 socialUserInfo.getNickname()
         );
+        response.deliverToken(accessToken, refreshToken);
+        
+        log.info("OAuth 로그인 완료. userId: {}, provider: {}", user.getId(), provider);
+        return response;
     }
 
     private OAuthCodeUserInfoProvider getProviderOrThrow(String provider) {
@@ -129,5 +148,36 @@ public class OauthServiceImpl implements OauthService {
         }
         
         return normalized;
+    }
+
+    @Override
+    public TokenSuccessResponse refreshTokens(String refreshToken) {
+        log.info("리프레시 토큰 재발급 요청");
+        
+        // 1. 리프레시 토큰 유효성 검증
+        Claims refreshClaims = jwtTokenProvider.parseAndValidateRefreshToken(refreshToken);
+        if (refreshClaims == null) {
+            log.warn("유효하지 않은 리프레시 토큰입니다");
+            throw new InvalidRefreshTokenException("리프레시 토큰이 유효하지 않거나 파싱할 수 없습니다");
+        }
+
+        // 2. 리프레시 토큰에서 사용자 ID 추출
+        Long userId = Long.valueOf(jwtTokenProvider.getRefreshUsername(refreshToken));
+
+        // 3. Redis에 저장된 토큰과 일치하는지 검증
+        if (!refreshTokenService.isValidRefresh(userId, refreshToken)) {
+            log.warn("Redis에 저장된 토큰과 일치하지 않음. userId: {}", userId);
+            throw new ExpiredRefreshTokenException(userId);
+        }
+
+        // 4. 새로운 액세스 토큰과 리프레시 토큰 생성
+        String newAccessToken = jwtTokenProvider.createAccessToken(userId);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        // 5. Redis에서 리프레시 토큰 회전 (기존 토큰 무효화 및 새 토큰 저장)
+        refreshTokenService.rotateRefresh(userId, newRefreshToken);
+
+        log.info("리프레시 토큰 재발급 완료. userId: {}", userId);
+        return new TokenSuccessResponse(newAccessToken, newRefreshToken);
     }
 }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
**리프레시 토큰 재발급 API 구현**
    - 액세스 토큰이 만료되었을 때 액세스/리프레시 토큰 쌍을 재발급
    - 요청값으로 리프레시 토큰을 받아 해당 토큰의 유효성을 검증 및 사용자 정보를 추출
    - 유효한 토큰임이 인증되면, 기존 리프레시 토큰 무효화 후 새 토큰 쌍 발급
    - 토큰은 rotation
   
**관련 예외 객체 추가
Swagger Docs 내용 보충**

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과
<img width="1222" height="114" alt="image" src="https://github.com/user-attachments/assets/9527b40a-a4fc-48ec-a717-00ef9348187d" />

<img width="363" height="168" alt="image" src="https://github.com/user-attachments/assets/0def4b40-efec-4ad6-adc8-11162fe8b9e5" />

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - /api/oauth/refresh 엔드포인트 추가: 리프레시 토큰 제출로 신규 액세스·리프레시 토큰 발급(토큰 회전, 인증 없이 호출 가능).
  - 카카오 로그인 응답에 토큰을 쿠키 대신 응답 본문으로 포함하도록 변경.
- **Bug Fixes**
  - 리프레시 토큰 검증/회전 흐름 강화 및 Redis 관련 오류 처리 개선으로 실패 상황에 대한 응답이 명확해짐.
- **Documentation**
  - 로그인·토큰 관련 Swagger/OpenAPI 메타데이터 보강 (응답 예시 및 필드 설명 추가).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->