### PR TITLE
[Y26W2-250] 인증이 불필요한 메서드, 클래스에 대한 PublicApi 어노테이션 추가

### DIFF
--- a/src/main/java/com/yapp/backend/common/annotation/PublicApi.java
+++ b/src/main/java/com/yapp/backend/common/annotation/PublicApi.java
@@ -1,0 +1,30 @@
+package com.yapp.backend.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * JWT 인증이 필요하지 않은 공개 API를 명시하는 어노테이션
+ * 
+ * 이 어노테이션이 붙은 메서드는 JwtFilter에서 인증을 건너뛰고,
+ * 누구나 접근할 수 있는 공개 엔드포인트로 처리됩니다.
+ * 
+ * 사용 예시:
+ * - OAuth 로그인 엔드포인트
+ * - 리프레시 토큰 재발급 API
+ * - 공개 데이터 조회 API
+ *
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PublicApi {
+    
+    /**
+     * 공개 API에 대한 설명
+     * 
+     * @return 해당 API가 공개된 이유나 용도 설명
+     */
+    String description() default "";
+}

--- a/src/main/java/com/yapp/backend/controller/ComparisonTableController.java
+++ b/src/main/java/com/yapp/backend/controller/ComparisonTableController.java
@@ -1,5 +1,6 @@
 package com.yapp.backend.controller;
 
+import com.yapp.backend.common.annotation.PublicApi;
 import com.yapp.backend.common.response.ResponseType;
 import com.yapp.backend.common.response.StandardResponse;
 import com.yapp.backend.controller.docs.ComparisonDocs;
@@ -36,6 +37,7 @@ public class ComparisonTableController implements ComparisonDocs {
     private final ComparisonTableService comparisonTableService;
 
     @Override
+    @PublicApi(description = "비교 기준 항목 목록 조회 - 인증 불필요")
     @GetMapping("/factors")
     public ResponseEntity<StandardResponse<ComparisonFactorList>> getComparisonFactorList() {
         return ResponseEntity.ok(
@@ -48,6 +50,7 @@ public class ComparisonTableController implements ComparisonDocs {
 
 
     @Override
+    @PublicApi(description = "편의시설 항목 목록 조회 - 인증 불필요")
     @GetMapping("/amenity")
     public ResponseEntity<StandardResponse<AmenityFactorList>> getAmenityFactorList() {
         return ResponseEntity.ok(

--- a/src/main/java/com/yapp/backend/controller/OauthController.java
+++ b/src/main/java/com/yapp/backend/controller/OauthController.java
@@ -2,10 +2,10 @@ package com.yapp.backend.controller;
 
 import static com.yapp.backend.common.response.ResponseType.*;
 import static com.yapp.backend.common.util.CookieUtil.REFRESH_TOKEN_COOKIE;
-import static com.yapp.backend.filter.JwtFilter.ACCESS_TOKEN_HEADER;
 import static com.yapp.backend.common.util.TokenUtil.extractTokenFromHeader;
 
 import com.google.common.net.HttpHeaders;
+import com.yapp.backend.common.annotation.PublicApi;
 import com.yapp.backend.common.response.StandardResponse;
 import com.yapp.backend.common.util.JwtTokenProvider;
 import com.yapp.backend.common.util.CookieUtil;
@@ -20,9 +20,6 @@ import com.yapp.backend.filter.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import com.yapp.backend.service.UserService;
-import com.yapp.backend.filter.dto.CustomUserDetails;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +50,7 @@ public class OauthController implements OauthDocs {
      * @return 카카오 OAuth 인가 URL
      */
     @Override
+    @PublicApi(description = "카카오 OAuth 인가 URL 조회 - 인증 불필요")
     @GetMapping("/kakao/authorize")
     public ResponseEntity<StandardResponse<AuthorizeUrlResponse>> getKakaoAuthorizeUrl(
             @RequestParam("baseUrl") String baseUrl) {
@@ -71,6 +69,7 @@ public class OauthController implements OauthDocs {
      * @return 사용자 정보 응답 (토큰은 쿠키로 전달)
      */
     @Override
+    @PublicApi(description = "카카오 OAuth 토큰 교환 - 인증 불필요")
     @PostMapping("/kakao/token")
     public ResponseEntity<StandardResponse<OauthLoginResponse>> exchangeKakaoToken(
             @RequestParam("code") String code,

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -3,6 +3,7 @@ package com.yapp.backend.filter;
 import static com.yapp.backend.common.util.TokenUtil.extractTokenFromHeader;
 import static com.yapp.backend.common.util.CookieUtil.getCookieValue;
 
+import com.yapp.backend.common.annotation.PublicApi;
 import com.yapp.backend.common.util.JwtTokenProvider;
 import com.yapp.backend.filter.service.AuthContextService;
 import com.yapp.backend.filter.service.RefreshTokenService;
@@ -19,6 +20,9 @@ import lombok.extern.slf4j.Slf4j;
 import io.jsonwebtoken.JwtException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
 @Component
@@ -28,26 +32,78 @@ public class JwtFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthContextService authContextService;
     private final RefreshTokenService refreshTokenService;
+    
+    @Autowired
+    private RequestMappingHandlerMapping requestMappingHandlerMapping;
 
     public static final String ACCESS_TOKEN_HEADER = "access-token";
     public static final String REFRESH_TOKEN_COOKIE = "REFRESH_TOKEN";
 
-    // 스킵할 URI(인증이 필요 없는 엔드포인트)
-
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
+        // 1. 시스템 관련 URI는 기본적으로 스킵 (OAuth2, Swagger, 에러 페이지 등)
         String uri = request.getRequestURI();
+        if (isSystemUri(uri)) {
+            return true;
+        }
+        
+        // 2. @PublicApi 어노테이션이 붙은 컨트롤러 메서드는 스킵
+        return isPublicApiEndpoint(request);
+    }
+    
+    /**
+     * 시스템 관련 URI 체크 (OAuth2, Swagger, 에러 페이지 등)
+     * 이러한 URI들은 Spring Security 또는 시스템에서 자동으로 처리되는 경로들
+     */
+    private boolean isSystemUri(String uri) {
         return uri.startsWith("/oauth2/authorization")
                 || uri.startsWith("/oauth2/authorize")
                 || uri.startsWith("/login/oauth2/code")
                 || uri.equals("/")
                 || uri.startsWith("/error")
                 || uri.startsWith("/swagger")
-                || uri.startsWith("/v3/api-docs")
-                || uri.startsWith("/api/comparison/factors")
-                || uri.startsWith("/api/comparison/amenity")
-                || uri.startsWith("/api/oauth/kakao")
-                ;
+                || uri.startsWith("/v3/api-docs");
+    }
+    
+    /**
+     * @PublicApi 어노테이션이 붙은 엔드포인트인지 체크
+     */
+    private boolean isPublicApiEndpoint(HttpServletRequest request) {
+        try {
+            // HandlerExecutionChain을 먼저 가져와서 null 체크
+            var handlerExecutionChain = requestMappingHandlerMapping.getHandler(request);
+            if (handlerExecutionChain == null) {
+                log.debug("핸들러를 찾을 수 없습니다: {}", request.getRequestURI());
+                return false;
+            }
+            
+            // Handler를 가져와서 null 체크 및 타입 확인
+            Object handler = handlerExecutionChain.getHandler();
+            if (!(handler instanceof HandlerMethod)) {
+                log.debug("HandlerMethod가 아닙니다: {}", request.getRequestURI());
+                return false;
+            }
+            
+            HandlerMethod handlerMethod = (HandlerMethod) handler;
+            
+            // 메서드 레벨에서 @PublicApi 어노테이션 체크
+            if (handlerMethod.hasMethodAnnotation(PublicApi.class)) {
+                log.debug("@PublicApi 어노테이션이 붙은 메서드: {}", handlerMethod.getMethod().getName());
+                return true;
+            }
+            
+            // 클래스 레벨에서 @PublicApi 어노테이션 체크
+            if (handlerMethod.getBeanType().isAnnotationPresent(PublicApi.class)) {
+                log.debug("@PublicApi 어노테이션이 붙은 클래스: {}", handlerMethod.getBeanType().getSimpleName());
+                return true;
+            }
+            
+        } catch (Exception e) {
+            // 핸들러를 찾을 수 없는 경우 (404 등) 인증 필요로 처리
+            log.debug("핸들러 조회 중 오류 발생: {} - {}", request.getRequestURI(), e.getMessage());
+        }
+        
+        return false;
     }
 
     @Override


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- `@PublicApi` 어노테이션 추가
- JwtFilter에서 어노테이션을 붙일 수 없는 리다이렉트 경로나 시스템 경로를 제외한 API 엔드포인트에 대해서 어노테이션을 확인해 인증 스킵 여부를 확인합니다.

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 카카오 OAuth 인가 URL 조회 및 토큰 교환 엔드포인트를 인증 없이 사용할 수 있습니다.
  - 비교 기준 항목, 편의시설 항목 조회 및 공유 코드 기반 비교표 조회를 인증 없이 이용할 수 있습니다.

- 리팩터
  - 공용 엔드포인트 인증 우회 판정 로직을 정비하여 공용 API 식별과 처리 안정성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->