### PR TITLE
[Y26W2-300] 스웨거 인증 에러 및 /error 경로에서 인증 미진행

### DIFF
--- a/src/main/java/com/yapp/backend/config/SecurityConfig.java
+++ b/src/main/java/com/yapp/backend/config/SecurityConfig.java
@@ -74,7 +74,8 @@ public class SecurityConfig {
                                                 .requestMatchers(
                                                                 "/",
                                                                 "/api/**",
-                                                                "/login/oauth2/**"
+                                                                "/login/oauth2/**",
+                                                                "/error" // Spring Boot 전역 에러 처리용
                                                 ).permitAll()
                                                 .anyRequest().authenticated())
                                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/yapp/backend/config/SecurityConfig.java
+++ b/src/main/java/com/yapp/backend/config/SecurityConfig.java
@@ -52,9 +52,12 @@ public class SecurityConfig {
                 return http
                                 .securityMatcher(
                                                 "/swagger/**",
+                                                "/swagger-ui",
                                                 "/swagger-ui/**",
                                                 "/swagger-ui.html",
-                                                "/v3/api-docs/**")
+                                                "/v3/api-docs",
+                                                "/v3/api-docs/**"
+                                        )
                                 .csrf(AbstractHttpConfigurer::disable)
                                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // WebConfig의 CORS 설정
                                 .authorizeHttpRequests(authorize -> authorize

--- a/src/main/java/com/yapp/backend/config/SecurityConfig.java
+++ b/src/main/java/com/yapp/backend/config/SecurityConfig.java
@@ -61,7 +61,6 @@ public class SecurityConfig {
                                 .csrf(AbstractHttpConfigurer::disable)
                                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // WebConfig의 CORS 설정
                                 .authorizeHttpRequests(authorize -> authorize
-                                                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()         // CORS preflight 허용
                                                 .anyRequest().authenticated())
                                 .httpBasic(httpBasic -> httpBasic.authenticationEntryPoint(basicAuthEntryPoint()))
                                 .exceptionHandling(e -> e.authenticationEntryPoint(basicAuthEntryPoint()))

--- a/src/main/java/com/yapp/backend/config/SecurityConfig.java
+++ b/src/main/java/com/yapp/backend/config/SecurityConfig.java
@@ -8,16 +8,20 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -53,8 +57,8 @@ public class SecurityConfig {
                                                 "/v3/api-docs/**")
                                 .csrf(AbstractHttpConfigurer::disable)
                                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // WebConfig의 CORS 설정
-                                                                                                   // 사용
                                 .authorizeHttpRequests(authorize -> authorize
+                                                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()         // CORS preflight 허용
                                                 .anyRequest().authenticated())
                                 .httpBasic(httpBasic -> httpBasic.authenticationEntryPoint(basicAuthEntryPoint()))
                                 .exceptionHandling(e -> e.authenticationEntryPoint(basicAuthEntryPoint()))

--- a/src/main/java/com/yapp/backend/config/SecurityConfig.java
+++ b/src/main/java/com/yapp/backend/config/SecurityConfig.java
@@ -56,8 +56,9 @@ public class SecurityConfig {
                                                                                                    // 사용
                                 .authorizeHttpRequests(authorize -> authorize
                                                 .anyRequest().authenticated())
-                                .httpBasic(httpBasic -> {
-                                })
+                                .httpBasic(httpBasic -> httpBasic.authenticationEntryPoint(basicAuthEntryPoint()))
+                                .exceptionHandling(e -> e.authenticationEntryPoint(basicAuthEntryPoint()))
+                                .requestCache(RequestCacheConfigurer::disable)
                                 .build();
         }
 
@@ -82,6 +83,13 @@ public class SecurityConfig {
                                                 .authenticationEntryPoint(customAuthenticationEntryPoint)
                                                 .accessDeniedHandler(customAccessDeniedHandler))
                                 .build();
+        }
+
+        @Bean
+        AuthenticationEntryPoint basicAuthEntryPoint() {
+                BasicAuthenticationEntryPoint basicAuthenticationEntryPoint = new BasicAuthenticationEntryPoint();
+                basicAuthenticationEntryPoint.setRealmName("ssok-api");
+                return basicAuthenticationEntryPoint;
         }
 
         @Bean

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -43,6 +43,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 || uri.equals("/")
                 || uri.startsWith("/error")
                 || uri.startsWith("/swagger")
+                || uri.startsWith("/swagger-ui/**")
                 || uri.startsWith("/v3/api-docs")
                 || uri.startsWith("/api/comparison/factors")
                 || uri.startsWith("/api/comparison/amenity")

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -43,7 +43,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 || uri.equals("/")
                 || uri.startsWith("/error")
                 || uri.startsWith("/swagger")
-                || uri.startsWith("/swagger-ui/**")
+                || uri.startsWith("/swagger-ui")
                 || uri.startsWith("/v3/api-docs")
                 || uri.startsWith("/api/comparison/factors")
                 || uri.startsWith("/api/comparison/amenity")

--- a/src/main/java/com/yapp/backend/filter/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/yapp/backend/filter/handler/CustomAuthenticationEntryPoint.java
@@ -29,7 +29,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     public void commence(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException authException) throws IOException, ServletException {
 
-        log.warn("Authentication failed for request {}: {}", request.getRequestURI(), authException.getMessage());
+        log.warn("Authentication failed for request {}: {}, {}" , authException.getClass(), request.getRequestURI(), authException.getMessage());
         Sentry.captureException(authException);
 
         // ErrorCode 사용하여 일관된 응답 생성


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
🚨 일부 브라우저/PC에서 swagger 접속시 Basic Auth 팝업이 뜨지 않고 401 인증 에러나는 문제

**의심가는 원인**
1. basic realm 누락
- basic auth가 뜨기 위한 조건 : 401 + 헤더에 `WWW-Authenticate: Basic realm "Realm"` 
-> realm 파라미터는 RFC 스펙상 필수 항목
- 없는 경우도 동작할 수 있지만, 일부 브라우저·클라이언트가 팝업을 띄우지 않거나 기본값 처리하는 경우 있음
- 지정하지 않으면 Spring Boot가 "Realm" 또는 공백 상태로 보내기도 하는데, 
일부 브라우저는 이걸 신뢰하지 않고 팝업을 띄우지 않을 수 있음 (현재는 Realm으로 오고 있음)
  <img width="383" height="52" alt="image" src="https://github.com/user-attachments/assets/4c3e5491-3d87-4d80-b63f-e7bd79f70d6e" />

    => httpBasic 필터, 혹은 그 외의 예외 상황에서 realm 파라미터 ("ssok-api") 가 전달되도록 추가해주었습니다.
  <img width="390" height="56" alt="image" src="https://github.com/user-attachments/assets/4e6305ea-0e62-4251-a854-27eec3caa655" />


2. 특정 네트워크에서만 안된다? -> 중간 프록시나 보안 SW?
`curl -I https://api.ssok.info/swagger-ui/` 로 요청했을 때 헤더가 없으면 프록시 문제


3. 같은 네트워크에서도 특정 PC나 계정에서만 팝업 미노출된다면?
`https://user:pass@api.ssok.info/swagger-ui`로 접속했을 때 열리면 브라우저에서 팝업이 차단된 것..

++ swagger 관련 경로에서 슬래시를 제외한 경로도 추가

<br></br>
📍 **그 외 변경 사항**
- 가끔 /error 경로로 redirect 되면서 `InsufficientAuthenticationException` 예외가 발생해 아래와 같은 인증 누락 경고 로그가 생겨서 해당 경로에 대해 인증을 확인하지 않도록 추가

<img width="1060" height="39" alt="image" src="https://github.com/user-attachments/assets/726974f1-318b-4ac8-8979-90b3188c56c0" />
<img width="715" height="40" alt="image" src="https://github.com/user-attachments/assets/b6cb03d1-d2dc-4d99-b8a3-626498463426" />


### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [ ] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 해당 사항 없음

- **버그 수정**
  - Swagger UI 및 OpenAPI 문서 페이지를 로그인 없이 접근 가능하도록 개선했습니다.
  - 글로벌 오류 엔드포인트("/error")를 공개 경로로 추가해 오류 페이지 접근이 인증으로 차단되지 않도록 했습니다.
  - 브라우저 CORS 사전요청(OPTIONS)을 허용해 외부 호출 시 접근성과 인증 동작을 안정화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->