### PR TITLE
[Y26W2-298] 유저 정보 조회 API

### DIFF
--- a/src/main/java/com/yapp/backend/controller/UserController.java
+++ b/src/main/java/com/yapp/backend/controller/UserController.java
@@ -39,7 +39,7 @@ public class UserController implements UserDocs {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         
         Long userId = userDetails.getUserId();
-        User user = userService.getUserById(userId);
+        User user = userService.getActiveUserById(userId);
 
         UserInfoResponse response = new UserInfoResponse(
             user.getNickname(),

--- a/src/main/java/com/yapp/backend/controller/UserController.java
+++ b/src/main/java/com/yapp/backend/controller/UserController.java
@@ -1,0 +1,51 @@
+package com.yapp.backend.controller;
+
+import static com.yapp.backend.common.response.ResponseType.SUCCESS;
+
+import com.yapp.backend.common.response.StandardResponse;
+import com.yapp.backend.controller.docs.UserDocs;
+import com.yapp.backend.controller.dto.response.UserInfoResponse;
+import com.yapp.backend.filter.dto.CustomUserDetails;
+import com.yapp.backend.service.UserService;
+import com.yapp.backend.service.model.User;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController implements UserDocs {
+
+    private final UserService userService;
+
+    /**
+     * 사용자 정보 조회 API
+     * 현재 로그인한 사용자의 기본 정보를 조회합니다.
+     *
+     * @param userDetails 현재 인증된 사용자 정보
+     * @return 사용자 닉네임과 프로필 이미지 URL
+     */
+    @Override
+    @SecurityRequirement(name = "JWT")
+    @GetMapping("/me")
+    public ResponseEntity<StandardResponse<UserInfoResponse>> getUserInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        
+        Long userId = userDetails.getUserId();
+        User user = userService.getUserById(userId);
+
+        UserInfoResponse response = new UserInfoResponse(
+            user.getNickname(),
+            user.getProfileImage()
+        );
+        
+        return ResponseEntity.ok(new StandardResponse<>(SUCCESS, response));
+    }
+}

--- a/src/main/java/com/yapp/backend/controller/docs/UserDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/UserDocs.java
@@ -1,0 +1,37 @@
+package com.yapp.backend.controller.docs;
+
+import com.yapp.backend.common.response.StandardResponse;
+import com.yapp.backend.controller.dto.response.UserInfoResponse;
+import com.yapp.backend.filter.dto.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "USER API", description = "사용자 관련 API")
+public interface UserDocs {
+
+    @Operation(
+            summary = "사용자 정보 조회",
+            description = "현재 로그인한 사용자의 기본 정보(닉네임, 프로필 이미지)를 조회합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "사용자 정보 조회 성공"
+    )
+    @ApiResponse(
+            responseCode = "401",
+            description = "인증되지 않은 사용자"
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음 또는 탈퇴한 사용자"
+    )
+    @SecurityRequirement(name = "JWT")
+    ResponseEntity<StandardResponse<UserInfoResponse>> getUserInfo(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/com/yapp/backend/controller/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/UserInfoResponse.java
@@ -1,0 +1,17 @@
+package com.yapp.backend.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "유저 정보 응답")
+public class UserInfoResponse {
+    
+    @Schema(description = "유저 닉네임", example = "홍길동")
+    private String nickname;
+    
+    @Schema(description = "유저 프로필 이미지 URL", example = "https://example.com/profile/user123.jpg")
+    private String profileImageUrl;
+}

--- a/src/main/java/com/yapp/backend/filter/service/AuthContextService.java
+++ b/src/main/java/com/yapp/backend/filter/service/AuthContextService.java
@@ -25,7 +25,7 @@ public class AuthContextService {
      */
     public Authentication createAuthContext(String accessToken) {
         String userId = jwtTokenProvider.getUserIdFromToken(accessToken);
-        User user = userService.getUserById(Long.valueOf(userId));
+        User user = userService.getActiveUserById(Long.valueOf(userId));
         // userId와 socialId로 customOauthUserDetail을 만든 Authentication 객체를 SecurityContext에 저장합니다.
         UserDetails userDetails = jwtTokenProvider.createUserDetails(accessToken, user.getSocialId());
         UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/yapp/backend/repository/UserRepository.java
+++ b/src/main/java/com/yapp/backend/repository/UserRepository.java
@@ -3,8 +3,25 @@ package com.yapp.backend.repository;
 import com.yapp.backend.service.model.User;
 
 public interface UserRepository {
+    /**
+     * 탈퇴 여부 고려하지 않고 모든 유저 조회
+     * @param id
+     * @return
+     */
     User findByIdOrThrow(Long id);
+
+    /**
+     * 소셜 로그인 정보를 통해
+     * 탈퇴하지 않은 활성 유저만 조회, 없으면 새로운 사용자 생성
+     * @param socialUserInfo
+     * @return
+     */
     User getUserBySocialUserInfoOrCreateUser(User socialUserInfo);
-    void deleteById(Long userId);
+
+    /**
+     * 유저 정보 저장
+     * @param user
+     * @return
+     */
     User save(User user);
 }

--- a/src/main/java/com/yapp/backend/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/UserRepositoryImpl.java
@@ -17,9 +17,9 @@ public class UserRepositoryImpl implements UserRepository {
     private final JpaUserRepository jpaUserRepository;
     private final UserMapper userMapper;
 
+
     @Override
     public User findByIdOrThrow(Long id) {
-        // TODO : 여행 보드 참여자 리스트를 조회할 때, 문제가 생길 여지가 있는지 확인
         return jpaUserRepository.findById(id)
                 .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND))
                 .toModel();
@@ -27,18 +27,12 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public User getUserBySocialUserInfoOrCreateUser(User socialUserInfo) {
-        // 삭제되지 않은 활성 사용자만 조회하고, 없으면 새로운 사용자 생성
         return jpaUserRepository
                 .findByProviderAndSocialIdAndDeletedAtIsNull(socialUserInfo.getProvider(), socialUserInfo.getSocialId())
                 .orElseGet(() -> jpaUserRepository.save(UserEntity.from(socialUserInfo)))
                 .toModel();
     }
 
-    // TODO: 회원 탈퇴 기능 구현 (hard delete)
-    @Override
-    public void deleteById(Long userId) {
-
-    }
 
     @Override
     public User save(User user) {

--- a/src/main/java/com/yapp/backend/service/UserService.java
+++ b/src/main/java/com/yapp/backend/service/UserService.java
@@ -1,7 +1,7 @@
 package com.yapp.backend.service;
 
+import com.yapp.backend.common.exception.DeletedUserException;
 import com.yapp.backend.service.model.User;
-import com.yapp.backend.controller.dto.response.WithdrawResponse;
 
 public interface UserService {
     /**
@@ -12,7 +12,7 @@ public interface UserService {
      * @return 사용자 도메인 모델 (활성 사용자만)
      * @throws DeletedUserException 탈퇴된 사용자인 경우
      */
-    User getUserById(Long userId);
+    User getActiveUserById(Long userId);
     
     /**
      * 회원탈퇴 처리 (Soft Delete)

--- a/src/main/java/com/yapp/backend/service/UserService.java
+++ b/src/main/java/com/yapp/backend/service/UserService.java
@@ -4,7 +4,15 @@ import com.yapp.backend.service.model.User;
 import com.yapp.backend.controller.dto.response.WithdrawResponse;
 
 public interface UserService {
-    User getUserById(Long id);
+    /**
+     * 활성 사용자 정보를 조회합니다.
+     * 탈퇴된 사용자인 경우 예외를 발생시킵니다.
+     * 
+     * @param userId 조회할 사용자 ID
+     * @return 사용자 도메인 모델 (활성 사용자만)
+     * @throws DeletedUserException 탈퇴된 사용자인 경우
+     */
+    User getUserById(Long userId);
     
     /**
      * 회원탈퇴 처리 (Soft Delete)

--- a/src/main/java/com/yapp/backend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/UserServiceImpl.java
@@ -21,8 +21,16 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
 
     @Override
-    public User getUserById(Long id) {
-        return userRepository.findByIdOrThrow(id);
+    public User getUserById(Long userId) {
+        
+        User user = userRepository.findByIdOrThrow(userId);
+        
+        // 탈퇴된 사용자인지 확인
+        if (user.getDeletedAt() != null) {
+            throw new DeletedUserException(DELETED_USER_ACCESS);
+        }
+        
+        return user;
     }
     
     @Override

--- a/src/main/java/com/yapp/backend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/UserServiceImpl.java
@@ -21,7 +21,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
 
     @Override
-    public User getUserById(Long userId) {
+    public User getActiveUserById(Long userId) {
         
         User user = userRepository.findByIdOrThrow(userId);
         


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 유저 닉네임, 프로필 조회 API 생성
- 유저서비스 레이어에서 활성사용자만 조회하는 메소드 `getActiveUserById`구현
(삭제된 유저가 조회될 경우 `DeletedUserException`예외)

 
### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항

탈퇴한 유저도 조회해야 할 경우를 고려해서
-> `UserRepository`에는 '**모든 유저 조회' (탈퇴여부 확인x)**
-> `UserService`에서 **탈퇴 여부 확인하여 '활성 유저 조회' 메소드** 구현 / **모든 유저 조회하여 그대로 사용**
위와 같은 흐름을 생각했습니다..!


### 테스트 결과
<img width="483" height="171" alt="image" src="https://github.com/user-attachments/assets/910c9a47-eeab-4954-8a0f-9ecbef050714" />

<img width="440" height="168" alt="image" src="https://github.com/user-attachments/assets/6e71df6f-bced-4b8e-ba01-94986f6d0005" />

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 현재 로그인한 사용자의 기본 정보를 반환하는 내 정보 조회 엔드포인트를 추가했습니다. JWT 인증이 필요하며 /api/users/me에서 닉네임과 프로필 이미지 URL을 확인할 수 있습니다. 비활성/탈퇴 계정은 접근 시 오류가 반환됩니다.
- Documentation
  - Swagger에 USER API 문서, 응답 스키마, 보안 요구사항(JWT), 상태 코드(200/401/404)를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->