### PR TITLE
[Y26W2-269] 비교 테이블 목록 조회 API

### DIFF
--- a/src/main/java/com/yapp/backend/controller/ComparisonTableController.java
+++ b/src/main/java/com/yapp/backend/controller/ComparisonTableController.java
@@ -10,6 +10,7 @@ import com.yapp.backend.controller.dto.response.AmenityFactorList;
 import com.yapp.backend.controller.dto.response.ComparisonFactorList;
 import com.yapp.backend.controller.dto.response.ComparisonTableDeleteResponse;
 import com.yapp.backend.controller.dto.response.ComparisonTableResponse;
+import com.yapp.backend.controller.dto.response.ComparisonTablePageResponse;
 import com.yapp.backend.controller.dto.response.CreateComparisonTableResponse;
 import com.yapp.backend.filter.dto.CustomUserDetails;
 import com.yapp.backend.service.ComparisonTableService;
@@ -30,7 +31,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @RestController
 @RequestMapping("/api/comparison")
@@ -121,6 +126,25 @@ public class ComparisonTableController implements ComparisonDocs {
                 .message("비교표가 성공적으로 삭제되었습니다.")
                 .build();
 
+        return ResponseEntity.ok(
+                new StandardResponse<>(ResponseType.SUCCESS, response));
+    }
+
+    @Override
+    @GetMapping("/trip-board/{tripBoardId}")
+    public ResponseEntity<StandardResponse<ComparisonTablePageResponse>> getComparisonTablesByTripBoard(
+            @PathVariable("tripBoardId") Long tripBoardId,
+            @RequestParam Integer page,
+            @RequestParam Integer size) {
+        
+        // 페이징 객체 생성 (최신순 정렬: 수정일 내림차순)
+        Pageable pageable = PageRequest.of(page, size,
+                Sort.by(Sort.Direction.DESC, "updatedAt"));
+        
+        // Service로부터 페이지네이션된 응답 조회
+        ComparisonTablePageResponse response = 
+                comparisonTableService.getComparisonTablesByTripBoardId(tripBoardId, pageable);
+        
         return ResponseEntity.ok(
                 new StandardResponse<>(ResponseType.SUCCESS, response));
     }

--- a/src/main/java/com/yapp/backend/controller/docs/ComparisonDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/ComparisonDocs.java
@@ -8,6 +8,7 @@ import com.yapp.backend.controller.dto.response.AmenityFactorList;
 import com.yapp.backend.controller.dto.response.ComparisonFactorList;
 import com.yapp.backend.controller.dto.response.ComparisonTableDeleteResponse;
 import com.yapp.backend.controller.dto.response.ComparisonTableResponse;
+import com.yapp.backend.controller.dto.response.ComparisonTablePageResponse;
 import com.yapp.backend.controller.dto.response.CreateComparisonTableResponse;
 import com.yapp.backend.filter.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,5 +73,19 @@ public interface ComparisonDocs {
     ResponseEntity<StandardResponse<ComparisonTableDeleteResponse>> deleteComparisonTable(
             @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "삭제할 비교표의 ID") Long tableId,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(
+            summary = "여행보드의 비교표 리스트 조회",
+            description = "특정 여행보드에 생성된 모든 비교표의 리스트를 무한스크롤 페이지네이션으로 조회합니다. " +
+                         "각 비교표의 기본 정보와 포함된 숙소 정보를 제공합니다."
+    )
+    @SecurityRequirement(name = "JWT")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비교표 리스트 조회 성공")
+    })
+    ResponseEntity<StandardResponse<ComparisonTablePageResponse>> getComparisonTablesByTripBoard(
+            @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "조회할 여행보드의 ID") Long tripBoardId,
+            @Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "페이지 번호 (0부터 시작)") Integer page,
+            @Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "integer"), description = "페이지 크기") Integer size);
 
 }

--- a/src/main/java/com/yapp/backend/controller/dto/response/ComparisonTablePageResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/ComparisonTablePageResponse.java
@@ -1,0 +1,33 @@
+package com.yapp.backend.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 비교표 목록 조회 API의 무한 스크롤 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ComparisonTablePageResponse {
+    private List<ComparisonTableSummaryResponse> comparisonTables;
+    private boolean hasNext;
+    
+    /**
+     * 정적 팩토리 메서드
+     * @param comparisonTables 비교표 요약 리스트
+     * @param hasNext 다음 페이지 존재 여부
+     * @return ComparisonTablePageResponse 객체
+     */
+    public static ComparisonTablePageResponse of(List<ComparisonTableSummaryResponse> comparisonTables, boolean hasNext) {
+        return ComparisonTablePageResponse.builder()
+                .comparisonTables(comparisonTables)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/src/main/java/com/yapp/backend/controller/dto/response/ComparisonTableSummaryResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/ComparisonTableSummaryResponse.java
@@ -1,0 +1,32 @@
+package com.yapp.backend.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "비교표 목록 조회 응답")
+public class ComparisonTableSummaryResponse {
+
+    @Schema(description = "비교표 ID", example = "1")
+    private Long tableId;
+
+    @Schema(description = "비교표 이름", example = "제주도 숙소 비교")
+    private String tableName;
+
+    @Schema(description = "포함된 숙소 개수", example = "3")
+    private Integer accommodationCount;
+
+    @Schema(description = "포함된 숙소 이름들", example = "[\"호텔 신라\", \"롯데 호텔\", \"그랜드 하이얏트\"]")
+    private List<String> accommodationNames;
+
+    @Schema(description = "최근 수정일", example = "2025-08-15T10:30:00")
+    private LocalDateTime lastModifiedAt;
+
+    @Schema(description = "공유 코드", accessMode = Schema.AccessMode.READ_ONLY, example = "4473fa9aed7044c7a94fa6e99..")
+    private String shareCode;
+}

--- a/src/main/java/com/yapp/backend/controller/dto/response/ComparisonTableSummaryResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/ComparisonTableSummaryResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 @Getter
@@ -24,8 +24,8 @@ public class ComparisonTableSummaryResponse {
     @Schema(description = "포함된 숙소 이름들", example = "[\"호텔 신라\", \"롯데 호텔\", \"그랜드 하이얏트\"]")
     private List<String> accommodationNames;
 
-    @Schema(description = "최근 수정일", example = "2025-08-15T10:30:00")
-    private LocalDateTime lastModifiedAt;
+    @Schema(description = "최근 수정일 (UTC)", example = "2025-08-15T08:30:00Z")
+    private ZonedDateTime lastModifiedAt;
 
     @Schema(description = "공유 코드", accessMode = Schema.AccessMode.READ_ONLY, example = "4473fa9aed7044c7a94fa6e99..")
     private String shareCode;

--- a/src/main/java/com/yapp/backend/controller/mapper/ComparisonTableResponseMapper.java
+++ b/src/main/java/com/yapp/backend/controller/mapper/ComparisonTableResponseMapper.java
@@ -1,0 +1,50 @@
+package com.yapp.backend.controller.mapper;
+
+import com.yapp.backend.controller.dto.response.ComparisonTableSummaryResponse;
+import com.yapp.backend.service.model.Accommodation;
+import com.yapp.backend.service.model.ComparisonTable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * ComparisonTable 도메인 모델을 Response DTO로 변환하는 매퍼 클래스
+ * Controller 레이어에서 Service로부터 받은 도메인 모델을 응답용 DTO로 변환합니다.
+ */
+@Component
+public class ComparisonTableResponseMapper {
+
+    /**
+     * ComparisonTable 도메인 모델을 ComparisonTableListResponse DTO로 변환
+     * 
+     * @param comparisonTable 비교표 도메인 모델
+     * @return 비교표 리스트 응답 DTO
+     */
+    public ComparisonTableSummaryResponse toSummaryResponse(ComparisonTable comparisonTable) {
+        List<String> accommodationNames = comparisonTable.getAccommodationList().stream()
+                .map(Accommodation::getAccommodationName)
+                .collect(Collectors.toList());
+
+        return new ComparisonTableSummaryResponse(
+                comparisonTable.getId(),
+                comparisonTable.getTableName(),
+                comparisonTable.getAccommodationList().size(),
+                accommodationNames,
+                comparisonTable.getUpdatedAt(),
+                comparisonTable.getShareCode()
+        );
+    }
+
+    /**
+     * ComparisonTable 도메인 모델 리스트를 ComparisonTableListResponse DTO 리스트로 변환
+     * 
+     * @param comparisonTables 비교표 도메인 모델 리스트
+     * @return 비교표 리스트 응답 DTO 리스트
+     */
+    public List<ComparisonTableSummaryResponse> toResponseList(List<ComparisonTable> comparisonTables) {
+        return comparisonTables.stream()
+                .map(this::toSummaryResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/yapp/backend/controller/mapper/ComparisonTableResponseMapper.java
+++ b/src/main/java/com/yapp/backend/controller/mapper/ComparisonTableResponseMapper.java
@@ -5,6 +5,8 @@ import com.yapp.backend.service.model.Accommodation;
 import com.yapp.backend.service.model.ComparisonTable;
 import org.springframework.stereotype.Component;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,7 +33,7 @@ public class ComparisonTableResponseMapper {
                 comparisonTable.getTableName(),
                 comparisonTable.getAccommodationList().size(),
                 accommodationNames,
-                comparisonTable.getUpdatedAt(),
+                comparisonTable.getUpdatedAt().withZoneSameInstant(ZoneOffset.UTC), // UTC로 명시적 변환 (ISO 8601 표준)
                 comparisonTable.getShareCode()
         );
     }

--- a/src/main/java/com/yapp/backend/repository/ComparisonTableRepository.java
+++ b/src/main/java/com/yapp/backend/repository/ComparisonTableRepository.java
@@ -1,6 +1,8 @@
 package com.yapp.backend.repository;
 
 import com.yapp.backend.service.model.ComparisonTable;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 public interface ComparisonTableRepository {
     Long save(ComparisonTable comparisonTable);
@@ -33,4 +35,12 @@ public interface ComparisonTableRepository {
      * 특정 숙소가 포함된 모든 비교표 매핑을 삭제합니다.
      */
     void removeAccommodationFromAllTables(Long accommodationId);
+
+    /**
+     * 특정 여행보드의 비교표 리스트를 페이지네이션으로 조회합니다.
+     * @param tripBoardId 여행보드 ID
+     * @param pageable 페이지네이션 정보
+     * @return 조회된 비교표 리스트
+     */
+    List<ComparisonTable> findByTripBoardId(Long tripBoardId, Pageable pageable);
 }

--- a/src/main/java/com/yapp/backend/repository/JpaComparisonTableRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaComparisonTableRepository.java
@@ -1,6 +1,8 @@
 package com.yapp.backend.repository;
 
 import com.yapp.backend.repository.entity.ComparisonTableEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +26,11 @@ public interface JpaComparisonTableRepository extends JpaRepository<ComparisonTa
     @Modifying
     @Query("DELETE FROM ComparisonAccommodationEntity ca WHERE ca.accommodationEntity.id = :accommodationId")
     void deleteComparisonAccommodationsByAccommodationId(@Param("accommodationId") Long accommodationId);
+
+    /**
+     * 특정 여행보드의 비교표 리스트를 페이지네이션으로 조회합니다. (최근 수정일 내림차순)
+     */
+    @Query("SELECT c FROM ComparisonTableEntity c WHERE c.tripBoardEntity.id = :tripBoardId ORDER BY c.updatedAt DESC")
+    Page<ComparisonTableEntity> findByTripBoardEntityIdOrderByUpdatedAtDesc(@Param("tripBoardId") Long tripBoardId, Pageable pageable);
+
 }

--- a/src/main/java/com/yapp/backend/repository/entity/ComparisonTableEntity.java
+++ b/src/main/java/com/yapp/backend/repository/entity/ComparisonTableEntity.java
@@ -17,7 +17,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -69,11 +69,11 @@ public class ComparisonTableEntity {
 
     @CreationTimestamp
     @Column(name = "created_at")
-    private LocalDateTime createdAt;
+    private ZonedDateTime createdAt;  // TIMESTAMPTZ와 매핑되어 UTC로 저장됨
 
     @UpdateTimestamp
     @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    private ZonedDateTime updatedAt;  // TIMESTAMPTZ와 매핑되어 UTC로 저장됨
 
     public void update(ComparisonTable updatedComparison) {
         this.tableName = updatedComparison.getTableName();

--- a/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -174,5 +176,25 @@ public class ComparisonTableRepositoryImpl implements ComparisonTableRepository 
     @Transactional
     public void removeAccommodationFromAllTables(Long accommodationId) {
         jpaComparisonTableRepository.deleteComparisonAccommodationsByAccommodationId(accommodationId);
+    }
+
+    @Override
+    public List<ComparisonTable> findByTripBoardId(Long tripBoardId, Pageable pageable) {
+        // Pageable 객체의 정렬 기준에 따라 적절한 JPA 메서드 선택
+        List<ComparisonTableEntity> entities = selectQueryMethodBySort(tripBoardId, pageable);
+
+        return entities.stream()
+                .map(comparisonTableMapper::entityToDomain)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Pageable의 Sort 정보를 분석하여 적절한 JPA 쿼리 메서드를 선택합니다.
+     * 현재는 최근 수정일 기준 내림차순만 지원하며, 향후 확장 가능합니다.
+     */
+    private List<ComparisonTableEntity> selectQueryMethodBySort(Long tripBoardId, Pageable pageable) {
+        // 현재는 최근 수정일 기준 내림차순만 지원
+        Page<ComparisonTableEntity> page = jpaComparisonTableRepository.findByTripBoardEntityIdOrderByUpdatedAtDesc(tripBoardId, pageable);
+        return page.getContent();
     }
 }

--- a/src/main/java/com/yapp/backend/service/ComparisonTableService.java
+++ b/src/main/java/com/yapp/backend/service/ComparisonTableService.java
@@ -4,15 +4,57 @@ import com.yapp.backend.controller.dto.request.AddAccommodationRequest;
 import com.yapp.backend.controller.dto.request.CreateComparisonTableRequest;
 import com.yapp.backend.controller.dto.request.UpdateComparisonTableRequest;
 import com.yapp.backend.controller.dto.response.ComparisonTableResponse;
+import com.yapp.backend.controller.dto.response.ComparisonTablePageResponse;
+import org.springframework.data.domain.Pageable;
 
 public interface ComparisonTableService {
+
+    /**
+     * 새로운 비교 테이블을 생성합니다.
+     * @param request
+     * @param userId
+     * @return
+     */
     Long createComparisonTable(CreateComparisonTableRequest request, Long userId);
 
+    /**
+     * 특정 비교 테이블의 상세 정보를 조회합니다.
+     * @param tableId
+     * @param userId
+     * @return
+     */
     ComparisonTableResponse getComparisonTable(Long tableId, Long userId);
 
+    /**
+     * 비교테이블의 상세 정보를 수정하고, 성공 여부를 반환합니다.
+     * @param tableId
+     * @param request
+     * @param userId
+     * @return
+     */
     Boolean updateComparisonTable(Long tableId, UpdateComparisonTableRequest request, Long userId);
 
+    /**
+     * 특정 비교 테이블에 새로운 숙소 정보를 추가합니다.
+     * @param tableId
+     * @param request
+     * @param userId
+     * @return
+     */
     ComparisonTableResponse addAccommodationToComparisonTable(Long tableId, AddAccommodationRequest request, Long userId);
 
+    /**
+     * 특졍 비교 테이블을 삭제하고, 관련된 숙소 매핑 정보도 함께 삭제합니다.
+     * @param tableId
+     * @param userId
+     */
     void deleteComparisonTable(Long tableId, Long userId);
+
+    /**
+     * 특정 여행보드의 비교표 리스트를 페이지네이션으로 조회합니다.
+     * @param tripBoardId 여행보드 ID
+     * @param pageable 페이지네이션 정보
+     * @return 페이지네이션된 비교표 리스트 응답
+     */
+    ComparisonTablePageResponse getComparisonTablesByTripBoardId(Long tripBoardId, Pageable pageable);
 }

--- a/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
@@ -9,6 +9,11 @@ import com.yapp.backend.controller.dto.request.UpdateAccommodationRequest;
 import com.yapp.backend.controller.dto.request.UpdateComparisonTableRequest;
 import com.yapp.backend.controller.dto.response.AccommodationResponse;
 import com.yapp.backend.controller.dto.response.ComparisonTableResponse;
+import com.yapp.backend.controller.dto.response.ComparisonTablePageResponse;
+import com.yapp.backend.controller.dto.response.ComparisonTableSummaryResponse;
+import com.yapp.backend.controller.mapper.ComparisonTableResponseMapper;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import com.yapp.backend.repository.AccommodationRepository;
 import com.yapp.backend.repository.ComparisonTableRepository;
 import com.yapp.backend.repository.TripBoardRepository;
@@ -43,6 +48,7 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
     private final UserRepository userRepository;
     private final AccommodationRepository accommodationRepository;
     private final AccommodationService accommodationService;
+    private final ComparisonTableResponseMapper responseMapper;
 
     @Override
     @Transactional
@@ -192,6 +198,37 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
             log.error("비교표 삭제 중 오류 발생 - tableId: {}, userId: {}", tableId, userId, e);
             throw new ComparisonTableDeleteException(ErrorCode.COMPARISON_TABLE_DELETE_FAILED);
         }
+    }
+
+    @Override
+    public ComparisonTablePageResponse getComparisonTablesByTripBoardId(Long tripBoardId, Pageable pageable) {
+        // 여행보드 존재 확인
+        tripBoardRepository.findByIdOrThrow(tripBoardId);
+
+        // hasNext 확인을 위해 size + 1개 조회하도록 Pageable 조정
+        int requestSize = pageable.getPageSize();
+        Pageable adjustedPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                requestSize + 1,
+                pageable.getSort()
+        );
+
+        // 페이지네이션된 비교표 리스트 조회
+        List<ComparisonTable> comparisonTables = comparisonTableRepository.findByTripBoardId(tripBoardId, adjustedPageable);
+        
+        // 다음 페이지 존재 여부 확인
+        boolean hasNext = comparisonTables.size() > requestSize;
+        
+        // 실제 반환할 데이터는 요청한 size만큼만
+        if (hasNext) {
+            comparisonTables = comparisonTables.subList(0, requestSize);
+        }
+        
+        // 매퍼를 사용하여 Response DTO로 변환
+        List<ComparisonTableSummaryResponse> responseList = responseMapper.toResponseList(comparisonTables);
+        
+        // 페이지 응답 객체로 감싸서 반환
+        return ComparisonTablePageResponse.of(responseList, hasNext);
     }
 
     /**

--- a/src/main/java/com/yapp/backend/service/model/ComparisonTable.java
+++ b/src/main/java/com/yapp/backend/service/model/ComparisonTable.java
@@ -3,7 +3,7 @@ package com.yapp.backend.service.model;
 import com.yapp.backend.common.util.ShareCodeGeneratorUtil;
 import com.yapp.backend.service.model.enums.ComparisonFactor;
 import jakarta.validation.constraints.NotBlank;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,8 +23,8 @@ public class ComparisonTable {
     private List<Accommodation> accommodationList;
     private List<ComparisonFactor> factors;
     private String shareCode;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
 
     public static ComparisonTable from(
             @NotBlank String tableName,

--- a/src/main/resources/config/postgresql/db-dev.yml
+++ b/src/main/resources/config/postgresql/db-dev.yml
@@ -4,6 +4,7 @@ spring:
     username: ${TEST_DB_USER}
     password: ${TEST_DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_PRIVATE_IP}:5432/${TEST_DB_NAME}?serverTimezone=UTC
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:

--- a/src/main/resources/config/postgresql/db-local.yml
+++ b/src/main/resources/config/postgresql/db-local.yml
@@ -1,7 +1,7 @@
 # 로컬 개발 시에 사용
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/${LOCAL_DB_NAME}
+    url: jdbc:postgresql://localhost:5432/${LOCAL_DB_NAME}?serverTimezone=UTC
     username: ${LOCAL_DB_USER}
     password: ${LOCAL_DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
@@ -10,13 +10,17 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: true
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
   cloud:
     gcp:
       sql:
         enabled: false
   flyway:
     enabled: true
-    url: jdbc:postgresql://localhost:5432/${LOCAL_DB_NAME}
+    url: jdbc:postgresql://localhost:5432/${LOCAL_DB_NAME}?serverTimezone=UTC
     user: ${LOCAL_DB_USER}
     password: ${LOCAL_DB_PASSWORD}
     locations: classpath:flyway/migration

--- a/src/main/resources/config/postgresql/db-prod.yml
+++ b/src/main/resources/config/postgresql/db-prod.yml
@@ -4,6 +4,7 @@ spring:
     username: ${PROD_DB_USER}
     password: ${PROD_DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_PRIVATE_IP}:5432/${PROD_DB_NAME}?serverTimezone=UTC
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항

**1. 비교 테이블 목록 페이지네이션 조회 API**

**2. 비교 테이블 수정시간을 UTC로 명시적 변환**

비교표 생성시에 Postgresql `TIMESTAMPTZ` 로 저장되며 **DB에서 UTC 기준으로 저장**되지만, 
조회를 통해 데이터를 가져올 때에는 `TIMESTAMPTZ` -> `LocalDateTime` 으로 매핑되면서 **KST 한국 시간으로 변환되어서 전달**되는 것을 확인

따라서 
- 데이터 타입을 `ZonedDateTime`으로 수정
- JPA 설정에 UTC 강제
- DataSource URL에 timezone 파라미터 `serverTimezone=UTC`

로 UTC 로 명시적으로 변환해주었습니다.

### PR 체크리스트
- [ ] 정상적으로 실행이 되나요?
- [ ] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [ ] 컨벤션 규칙을 지켰나요?
- [ ] merge branch 를 확인했나요?


### 추가 전달 사항

현재 PR에서는 비교표 테이블 조회에만 집중해서 데이터 타입을 변환하고,
이외에 다른 도메인(유저, 숙소, 여행 보드 등)에서는 아직 `LocalDateTime` 데이터 타입입니다!

날짜와 시간 등이 화면에 표시되어야할 경우 추후 한번에 리팩토링하면 좋을 것 같습니다!


### 테스트 결과
<img width="880" height="498" alt="image" src="https://github.com/user-attachments/assets/32e519ea-72d2-4870-90a8-eaf6eae83a39" />

<img width="542" height="361" alt="image" src="https://github.com/user-attachments/assets/1f80d2d7-cc4e-484e-8098-7d11d23911cf" />
<img width="485" height="398" alt="image" src="https://github.com/user-attachments/assets/896a9b13-71af-41d5-91bf-173a6a181639" />

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->