### PR TITLE
[Y26W2-316] 카카오 로그인 이후 유저 정보 저장 및 조회 시 이메일 추가

### DIFF
--- a/src/main/java/com/yapp/backend/controller/UserController.java
+++ b/src/main/java/com/yapp/backend/controller/UserController.java
@@ -43,7 +43,8 @@ public class UserController implements UserDocs {
 
         UserInfoResponse response = new UserInfoResponse(
             user.getNickname(),
-            user.getProfileImage()
+            user.getProfileImage(),
+            user.getEmail()
         );
         
         return ResponseEntity.ok(new StandardResponse<>(SUCCESS, response));

--- a/src/main/java/com/yapp/backend/controller/dto/response/OauthLoginResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/OauthLoginResponse.java
@@ -14,13 +14,17 @@ public class OauthLoginResponse {
         
         @Schema(description = "사용자 닉네임", example = "홍길동")
         private String nickname;
-        
+
+        @Schema(description = "사용자 이메일", example = "abc1234@gmail.com")
+        private String email;
+
         @Schema(description = "토큰 정보")
         private TokenSuccessResponse token;
 
-        public OauthLoginResponse(Long userId, String nickname) {
+        public OauthLoginResponse(Long userId, String nickname, String email) {
                 this.userId = userId;
                 this.nickname = nickname;
+                this.email = email;
         }
 
         public void deliverToken(String accessToken, String refreshToken) {

--- a/src/main/java/com/yapp/backend/controller/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/UserInfoResponse.java
@@ -14,4 +14,9 @@ public class UserInfoResponse {
     
     @Schema(description = "유저 프로필 이미지 URL", example = "https://example.com/profile/user123.jpg")
     private String profileImageUrl;
+
+    @Schema(description = "사용자 이메일", example = "abc1234@gmail.com")
+    private String email;
+
+
 }

--- a/src/main/java/com/yapp/backend/service/impl/OauthServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/OauthServiceImpl.java
@@ -80,7 +80,8 @@ public class OauthServiceImpl implements OauthService {
         // 6. 토큰 정보를 포함한 응답 생성
         OauthLoginResponse response = new OauthLoginResponse(
                 user.getId(),
-                socialUserInfo.getNickname()
+                user.getNickname(),
+                user.getEmail()
         );
         response.deliverToken(accessToken, refreshToken);
         

--- a/src/main/java/com/yapp/backend/service/oauth/KakaoOAuthCodeUserInfoProvider.java
+++ b/src/main/java/com/yapp/backend/service/oauth/KakaoOAuthCodeUserInfoProvider.java
@@ -44,7 +44,7 @@ public class KakaoOAuthCodeUserInfoProvider implements OAuthCodeUserInfoProvider
                 .queryParam("client_id", kakaoClientId)
                 .queryParam("redirect_uri", redirectUri)
                 .queryParam("response_type", "code")
-                .queryParam("scope", "profile_nickname,profile_image")
+                .queryParam("scope", "profile_nickname,profile_image,account_email")
                 .build()
                 .toUriString();
     }

--- a/src/main/resources/config/oauth/security.yml
+++ b/src/main/resources/config/oauth/security.yml
@@ -9,7 +9,7 @@ spring:
             authorization-grant-type: authorization_code
             redirect-uri: "${BASE_URL}/login/oauth2/code/kakao"
             client-authentication-method: client_secret_post
-            scope: profile_nickname, profile_image
+            scope: profile_nickname, profile_image, account_email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 카카오 동의항목에 account_email 추가(필수 동의로 설정)
- 소셜 로그인 성공 응답 DTO, 유저 정보 조회 DTO에 email 추가

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과
<img width="746" height="54" alt="image" src="https://github.com/user-attachments/assets/d9b21dfc-567b-499d-8073-61b90e17591e" />

<img width="340" height="193" alt="image" src="https://github.com/user-attachments/assets/c3531ab5-a121-4fbc-a6a2-0a506308fb5f" />
<img width="299" height="244" alt="image" src="https://github.com/user-attachments/assets/1d56545e-435b-46f8-bf28-060edaf0f6de" />

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 사용자 정보 조회와 소셜 로그인 응답에 이메일이 포함됩니다.
  - 카카오 로그인 과정에서 이메일 제공 동의가 추가로 요청될 수 있습니다.
  - 프로필/계정 화면에서 이메일 확인이 가능해집니다(앱/웹 구현 시 표시).
  - 이메일 포함으로 이메일 기반 알림·보안 확인 등의 호환성이 개선됩니다.
  - 기존 닉네임·프로필 이미지 정보는 변동 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->