### PR TITLE
[Y26W2-270] 공유 코드를 통한 비교 테이블 상세 조회 API

### DIFF
--- a/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/yapp/backend/common/exception/ErrorCode.java
@@ -72,7 +72,8 @@ public enum ErrorCode {
 
     // Comparison Table Delete related errors
     COMPARISON_TABLE_DELETE_FORBIDDEN("비교표 삭제 권한 없음", "본인이 생성한 비교표만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
-    COMPARISON_TABLE_DELETE_FAILED("비교표 삭제 실패", "비교표 삭제 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+    COMPARISON_TABLE_DELETE_FAILED("비교표 삭제 실패", "비교표 삭제 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_SHARE_CODE("유효하지 않은 공유 코드", "제공된 공유 코드가 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
     // 필요에 따라 추가
     ;
 

--- a/src/main/java/com/yapp/backend/common/exception/ShareCodeException.java
+++ b/src/main/java/com/yapp/backend/common/exception/ShareCodeException.java
@@ -1,0 +1,11 @@
+package com.yapp.backend.common.exception;
+
+/**
+ * 공유 코드 관련 예외
+ */
+public class ShareCodeException extends CustomException {
+    
+    public ShareCodeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/yapp/backend/controller/ComparisonTableController.java
+++ b/src/main/java/com/yapp/backend/controller/ComparisonTableController.java
@@ -30,14 +30,23 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.yapp.backend.service.model.ComparisonTable;
+import com.yapp.backend.common.exception.ErrorCode;
+import com.yapp.backend.common.exception.UserAuthorizationException;
+import lombok.extern.slf4j.Slf4j;
+import com.yapp.backend.controller.mapper.ComparisonTableResponseMapper;
+
+@Slf4j
 @RestController
 @RequestMapping("/api/comparison")
 @RequiredArgsConstructor
 public class ComparisonTableController implements ComparisonDocs {
 
     private final ComparisonTableService comparisonTableService;
+    private final ComparisonTableResponseMapper comparisonTableResponseMapper;
 
     @Override
     @GetMapping("/factors")
@@ -57,6 +66,7 @@ public class ComparisonTableController implements ComparisonDocs {
                         new AmenityFactorList(List.of(AmenityFactor.values()))));
     }
 
+    // TODO: 비교 테이블 관련 권한 검증
     @Override
     @PostMapping("/new")
     public ResponseEntity<StandardResponse<CreateComparisonTableResponse>> createComparisonTable(
@@ -74,15 +84,40 @@ public class ComparisonTableController implements ComparisonDocs {
     public ResponseEntity<StandardResponse<ComparisonTableResponse>> getComparisonTable(
             @PathVariable("tableId") Long tableId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        // TODO: 인증/인가 로직 리팩토링 - 해당 테이블 조회 권한이 있는지 확인 (여행그룹 참여 여부)
-        Long userId = userDetails.getUserId();
-        ComparisonTableResponse comparisonTableResponse = comparisonTableService.getComparisonTable(tableId,
-                userId);
-        return ResponseEntity.ok(
-                new StandardResponse<>(ResponseType.SUCCESS, comparisonTableResponse));
+
+        ComparisonTable comparisonTable = comparisonTableService.getComparisonTable(tableId);
+        ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable);
+        
+        return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
     }
 
-    // TODO: 비교표 수정 API
+    /**
+     * shareCode를 통한 비교표 조회 (인증 불필요)
+     */
+    @GetMapping("/{tableId}/shared")
+    public ResponseEntity<StandardResponse<ComparisonTableResponse>> getComparisonTableByShareCode(
+            @PathVariable("tableId") Long tableId,
+            @RequestParam("shareCode") String shareCode) {
+
+        ComparisonTable comparisonTable = comparisonTableService.getComparisonTable(tableId);
+        
+        // shareCode 검증
+        validateShareCodeAccess(tableId, shareCode, comparisonTable);
+        ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable);
+        return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
+    }
+
+    /**
+     * shareCode를 통한 접근 권한 검증
+     */
+    private void validateShareCodeAccess(Long tableId, String shareCode, ComparisonTable comparisonTable) {
+        if (!shareCode.equals(comparisonTable.getShareCode())) {
+            log.warn("유효하지 않은 shareCode로 비교표 조회 시도 - tableId: {}, shareCode: {}", tableId, shareCode);
+            throw new UserAuthorizationException(ErrorCode.INVALID_USER_AUTHORIZATION);
+        }
+        log.info("shareCode를 통한 비교표 조회 성공 - tableId: {}, shareCode: {}", tableId, shareCode);
+    }
+
     @Override
     @PutMapping("/{tableId}")
     public ResponseEntity<StandardResponse<Boolean>> updateComparisonTable(
@@ -102,10 +137,11 @@ public class ComparisonTableController implements ComparisonDocs {
             @RequestBody AddAccommodationRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();
-        ComparisonTableResponse response = comparisonTableService.addAccommodationToComparisonTable(tableId,
-                request, userId);
-        return ResponseEntity.ok(
-                new StandardResponse<>(ResponseType.SUCCESS, response));
+        
+        ComparisonTable comparisonTable = comparisonTableService.addAccommodationToComparisonTable(tableId, request, userId);
+        ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable);
+        
+        return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
     }
 
     @Override

--- a/src/main/java/com/yapp/backend/controller/ComparisonTableController.java
+++ b/src/main/java/com/yapp/backend/controller/ComparisonTableController.java
@@ -1,5 +1,8 @@
 package com.yapp.backend.controller;
 
+import static com.yapp.backend.common.exception.ErrorCode.*;
+
+import com.yapp.backend.common.exception.ShareCodeException;
 import com.yapp.backend.common.response.ResponseType;
 import com.yapp.backend.common.response.StandardResponse;
 import com.yapp.backend.controller.docs.ComparisonDocs;
@@ -113,7 +116,7 @@ public class ComparisonTableController implements ComparisonDocs {
     private void validateShareCodeAccess(Long tableId, String shareCode, ComparisonTable comparisonTable) {
         if (!shareCode.equals(comparisonTable.getShareCode())) {
             log.warn("유효하지 않은 shareCode로 비교표 조회 시도 - tableId: {}, shareCode: {}", tableId, shareCode);
-            throw new UserAuthorizationException(ErrorCode.INVALID_USER_AUTHORIZATION);
+            throw new ShareCodeException(INVALID_SHARE_CODE);
         }
         log.info("shareCode를 통한 비교표 조회 성공 - tableId: {}, shareCode: {}", tableId, shareCode);
     }

--- a/src/main/java/com/yapp/backend/controller/docs/ComparisonDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/ComparisonDocs.java
@@ -38,12 +38,36 @@ public interface ComparisonDocs {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
-    @Operation(summary = "비교표 조회", description = "비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다. (Authorization 헤더에 Bearer 토큰 필요)")
+    @Operation(
+        summary = "비교표 조회", 
+        description = "비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다. JWT 인증이 필요하며, 비교표 생성자 또는 여행보드 참여자만 접근 가능합니다."
+    )
     @SecurityRequirement(name = "JWT")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "비교표 조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 토큰"),
+        @ApiResponse(responseCode = "403", description = "권한 없음 - 해당 비교표에 접근 권한이 없음"),
+        @ApiResponse(responseCode = "404", description = "비교표를 찾을 수 없음")
+    })
     ResponseEntity<StandardResponse<ComparisonTableResponse>> getComparisonTable(
             @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "숙소가 포함된 테이블의 ID") Long tableId,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
+
+    @Operation(
+        summary = "shareCode를 통한 비교표 조회", 
+        description = "shareCode를 사용하여 인증 없이 비교표를 조회합니다. 유효한 shareCode가 필요합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "비교표 조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 shareCode"),
+        @ApiResponse(responseCode = "404", description = "비교표를 찾을 수 없음")
+    })
+    ResponseEntity<StandardResponse<ComparisonTableResponse>> getComparisonTableByShareCode(
+            @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "숙소가 포함된 테이블의 ID") Long tableId,
+            @Parameter(in = ParameterIn.QUERY, schema = @Schema(type = "string"), description = "비교표 공유 코드", required = true) String shareCode
+    );
+
 
     @Operation(summary = "비교표 수정", description = "비교표 메타 데이터(제목)와 숙소 세부 내용, 비교 기준 정렬 순서, 숙소 정렬 순서를 수정합니다. (Authorization 헤더에 Bearer 토큰 필요)")
     @SecurityRequirement(name = "JWT")

--- a/src/main/java/com/yapp/backend/controller/docs/ComparisonDocs.java
+++ b/src/main/java/com/yapp/backend/controller/docs/ComparisonDocs.java
@@ -44,10 +44,7 @@ public interface ComparisonDocs {
     )
     @SecurityRequirement(name = "JWT")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "비교표 조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 토큰"),
-        @ApiResponse(responseCode = "403", description = "권한 없음 - 해당 비교표에 접근 권한이 없음"),
-        @ApiResponse(responseCode = "404", description = "비교표를 찾을 수 없음")
+        @ApiResponse(responseCode = "200", description = "비교표 조회 성공")
     })
     ResponseEntity<StandardResponse<ComparisonTableResponse>> getComparisonTable(
             @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "숙소가 포함된 테이블의 ID") Long tableId,
@@ -59,9 +56,7 @@ public interface ComparisonDocs {
         description = "shareCode를 사용하여 인증 없이 비교표를 조회합니다. 유효한 shareCode가 필요합니다."
     )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "비교표 조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 실패 - 유효하지 않은 shareCode"),
-        @ApiResponse(responseCode = "404", description = "비교표를 찾을 수 없음")
+        @ApiResponse(responseCode = "200", description = "비교표 조회 성공")
     })
     ResponseEntity<StandardResponse<ComparisonTableResponse>> getComparisonTableByShareCode(
             @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "integer"), description = "숙소가 포함된 테이블의 ID") Long tableId,

--- a/src/main/java/com/yapp/backend/controller/dto/response/ComparisonTableResponse.java
+++ b/src/main/java/com/yapp/backend/controller/dto/response/ComparisonTableResponse.java
@@ -13,6 +13,7 @@ public class ComparisonTableResponse {
     private Long tableId;
     private String tableName;
     private List<AccommodationResponse> accommodationResponsesList;
+    private String shareCode;
     private List<ComparisonFactor> factorsList;
     private Long createdBy;
 }

--- a/src/main/java/com/yapp/backend/controller/mapper/ComparisonTableResponseMapper.java
+++ b/src/main/java/com/yapp/backend/controller/mapper/ComparisonTableResponseMapper.java
@@ -1,0 +1,31 @@
+package com.yapp.backend.controller.mapper;
+
+import com.yapp.backend.controller.dto.response.ComparisonTableResponse;
+import com.yapp.backend.controller.dto.response.AccommodationResponse;
+import com.yapp.backend.service.model.ComparisonTable;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+
+/**
+ * 비교표 도메인과 DTO 간의 변환을 담당하는 Mapper
+ */
+@Component
+public class ComparisonTableResponseMapper {
+
+    /**
+     * ComparisonTable 도메인을 ComparisonTableResponse DTO로 변환
+     */
+    public ComparisonTableResponse toResponse(ComparisonTable comparisonTable) {
+        return new ComparisonTableResponse(
+                comparisonTable.getId(),
+                comparisonTable.getTableName(),
+                comparisonTable.getAccommodationList().stream()
+                        .map(AccommodationResponse::from)
+                        .collect(Collectors.toList()),
+                comparisonTable.getShareCode(),
+                comparisonTable.getFactors(),
+                comparisonTable.getCreatedById()
+        );
+    }
+}

--- a/src/main/java/com/yapp/backend/filter/JwtFilter.java
+++ b/src/main/java/com/yapp/backend/filter/JwtFilter.java
@@ -48,6 +48,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 || uri.startsWith("/api/comparison/amenity")
                 || uri.startsWith("/api/oauth/kakao")
                 || uri.startsWith("/api/oauth/refresh")
+                || uri.matches("/api/comparison/[0-9]+/shared")
                 ;
     }
 

--- a/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/ComparisonTableRepositoryImpl.java
@@ -128,7 +128,7 @@ public class ComparisonTableRepositoryImpl implements ComparisonTableRepository 
         // 기존 숙소 ID 목록 추출 (중복 방지용)
         Set<Long> existingAccommodationIds = tableEntity.getItems().stream()
                 .map(item -> item.getAccommodationEntity().getId())
-                .collect(java.util.stream.Collectors.toSet());
+                .collect(Collectors.toSet());
 
         // 중복되지 않는 새로운 숙소 ID들만 필터링
         List<Long> newAccommodationIds = accommodationIds.stream()

--- a/src/main/java/com/yapp/backend/service/ComparisonTableService.java
+++ b/src/main/java/com/yapp/backend/service/ComparisonTableService.java
@@ -4,15 +4,16 @@ import com.yapp.backend.controller.dto.request.AddAccommodationRequest;
 import com.yapp.backend.controller.dto.request.CreateComparisonTableRequest;
 import com.yapp.backend.controller.dto.request.UpdateComparisonTableRequest;
 import com.yapp.backend.controller.dto.response.ComparisonTableResponse;
+import com.yapp.backend.service.model.ComparisonTable;
 
 public interface ComparisonTableService {
     Long createComparisonTable(CreateComparisonTableRequest request, Long userId);
 
-    ComparisonTableResponse getComparisonTable(Long tableId, Long userId);
+    ComparisonTable getComparisonTable(Long tableId);
 
     Boolean updateComparisonTable(Long tableId, UpdateComparisonTableRequest request, Long userId);
 
-    ComparisonTableResponse addAccommodationToComparisonTable(Long tableId, AddAccommodationRequest request, Long userId);
+    ComparisonTable addAccommodationToComparisonTable(Long tableId, AddAccommodationRequest request, Long userId);
 
     void deleteComparisonTable(Long tableId, Long userId);
 }

--- a/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
@@ -85,6 +85,7 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
                 comparisonTable.getAccommodationList().stream().map(AccommodationResponse::from)
                         .collect(
                                 Collectors.toList()),
+                comparisonTable.getShareCode(),
                 comparisonTable.getFactors(),
                 comparisonTable.getCreatedById()
         );
@@ -141,27 +142,23 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
             AddAccommodationRequest request,
             Long userId
     ) {
-        try {
-            ComparisonTable updatedTable = comparisonTableRepository.addAccommodationsToTable(
-                    tableId,
-                    request.getAccommodationIds(),
-                    userId
-            );
+        ComparisonTable updatedTable = comparisonTableRepository.addAccommodationsToTable(
+                tableId,
+                request.getAccommodationIds(),
+                userId
+        );
 
-            // 업데이트된 비교표 반환
-            return new ComparisonTableResponse(
-                    updatedTable.getId(),
-                    updatedTable.getTableName(),
-                    updatedTable.getAccommodationList().stream()
-                            .map(AccommodationResponse::from)
-                            .collect(Collectors.toList()),
-                    updatedTable.getFactors(),
-                    updatedTable.getCreatedById()
-            );
-
-        } catch (Exception e) {
-            throw new RuntimeException("비교표에 숙소 추가 중 오류가 발생했습니다.", e);
-        }
+        // 업데이트된 비교표 반환
+        return new ComparisonTableResponse(
+                updatedTable.getId(),
+                updatedTable.getTableName(),
+                updatedTable.getAccommodationList().stream()
+                        .map(AccommodationResponse::from)
+                        .collect(Collectors.toList()),
+                updatedTable.getShareCode(),
+                updatedTable.getFactors(),
+                updatedTable.getCreatedById()
+        );
     }
 
     @Override

--- a/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
@@ -77,19 +77,11 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
     }
 
     @Override
-    public ComparisonTableResponse getComparisonTable(Long tableId, Long userId) {
-        ComparisonTable comparisonTable = comparisonTableRepository.findByIdOrThrow(tableId);
-        return new ComparisonTableResponse(
-                comparisonTable.getId(),
-                comparisonTable.getTableName(),
-                comparisonTable.getAccommodationList().stream().map(AccommodationResponse::from)
-                        .collect(
-                                Collectors.toList()),
-                comparisonTable.getShareCode(),
-                comparisonTable.getFactors(),
-                comparisonTable.getCreatedById()
-        );
+    public ComparisonTable getComparisonTable(Long tableId) {
+        return comparisonTableRepository.findByIdOrThrow(tableId);
     }
+
+
 
     @Override
     @Transactional
@@ -137,27 +129,15 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
 
     @Override
     @Transactional
-    public ComparisonTableResponse addAccommodationToComparisonTable(
+    public ComparisonTable addAccommodationToComparisonTable(
             Long tableId,
             AddAccommodationRequest request,
             Long userId
     ) {
-        ComparisonTable updatedTable = comparisonTableRepository.addAccommodationsToTable(
+        return comparisonTableRepository.addAccommodationsToTable(
                 tableId,
                 request.getAccommodationIds(),
                 userId
-        );
-
-        // 업데이트된 비교표 반환
-        return new ComparisonTableResponse(
-                updatedTable.getId(),
-                updatedTable.getTableName(),
-                updatedTable.getAccommodationList().stream()
-                        .map(AccommodationResponse::from)
-                        .collect(Collectors.toList()),
-                updatedTable.getShareCode(),
-                updatedTable.getFactors(),
-                updatedTable.getCreatedById()
         );
     }
 


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 공유 코드를 파라미터로 받는 비교테이블 상세 조회 API 추가 (jwtFilter에서 제외)
- 서비스 레이어에서 도메인을 반환하고, 응답 DTO는 컨트롤러에서 생성하도록 중간에 mapper 객체 추가
- 공유 코드 관련 구체적인 예외 클래스 및 에러 코드 생성

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항
- 인증된 유저에 대한 권한 검증은 따로 작업하겠습니다!

### 테스트 결과

**공유코드 기반 비교테이블 조회 API 엔드포인트**
<img width="649" height="432" alt="image" src="https://github.com/user-attachments/assets/d6496221-3708-456c-9b8d-4ec1807b489b" />

**공유코드가 유효하지 않을 때 : 401**
<img width="529" height="267" alt="image" src="https://github.com/user-attachments/assets/360f2718-049e-4c18-ab57-2cb51d14f800" />


-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 공유 코드로 비교표를 조회하는 공개 엔드포인트 추가: GET /api/comparison/{id}/shared?shareCode=...
  - 비교표 응답에 shareCode 필드 포함 및 기존 조회/추가 응답이 일관된 형식으로 반환되도록 개선
  - 잘못된 공유 코드 제공 시 401 응답 반환
  - 인증 필터가 공유 조회 경로를 인증 예외로 처리하여 로그인 없이 접근 가능

- **문서**
  - 기존 및 신규 공유 조회 엔드포인트에 대한 API 문서(파라미터 및 응답 코드) 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->