### PR TITLE
[Y26W2-330] 숙소 등록시 인근교통편, 관광지 도보 및 차량 거리정보 안 나오는 이슈

### DIFF
--- a/src/main/java/com/yapp/backend/repository/mapper/ScrapingDataMapper.java
+++ b/src/main/java/com/yapp/backend/repository/mapper/ScrapingDataMapper.java
@@ -189,6 +189,9 @@ public class ScrapingDataMapper {
     }
 
     private DistanceInfo mapDistanceInfo(DistanceInfo scrapingDistanceInfo) {
+        if (scrapingDistanceInfo == null) {
+            return null;
+        }
         return DistanceInfo.builder()
                 .distance(scrapingDistanceInfo.getDistance())
                 .time(scrapingDistanceInfo.getTime())

--- a/src/main/java/com/yapp/backend/repository/mapper/ScrapingDataMapper.java
+++ b/src/main/java/com/yapp/backend/repository/mapper/ScrapingDataMapper.java
@@ -11,6 +11,7 @@ import com.yapp.backend.service.dto.ScrapingTransportation;
 import com.yapp.backend.service.dto.ScrapingCheckTime;
 import com.yapp.backend.service.model.Amenity;
 import com.yapp.backend.service.model.Attraction;
+import com.yapp.backend.service.model.DistanceInfo;
 import com.yapp.backend.service.model.Transportation;
 import com.yapp.backend.service.model.CheckTime;
 
@@ -152,8 +153,12 @@ public class ScrapingDataMapper {
                 .latitude(scrapingAttraction.getLatitude())
                 .longitude(scrapingAttraction.getLongitude())
                 .distance(scrapingAttraction.getDistance())
+                .byFoot(mapDistanceInfo(scrapingAttraction.getByFoot()))
+                .byCar(mapDistanceInfo(scrapingAttraction.getByCar()))
+
                 .build();
     }
+
 
     /**
      * 스크래핑 교통수단 리스트를 도메인 모델로 매핑합니다.
@@ -178,7 +183,17 @@ public class ScrapingDataMapper {
                 .latitude(scrapingTransportation.getLatitude())
                 .longitude(scrapingTransportation.getLongitude())
                 .distance(scrapingTransportation.getDistance())
+                .byFoot(mapDistanceInfo(scrapingTransportation.getByFoot()))
+                .byCar(mapDistanceInfo(scrapingTransportation.getByCar()))
                 .build();
+    }
+
+    private DistanceInfo mapDistanceInfo(DistanceInfo scrapingDistanceInfo) {
+        return DistanceInfo.builder()
+                .distance(scrapingDistanceInfo.getDistance())
+                .time(scrapingDistanceInfo.getTime())
+                .build();
+
     }
 
     /**

--- a/src/main/java/com/yapp/backend/service/dto/ScrapingAttraction.java
+++ b/src/main/java/com/yapp/backend/service/dto/ScrapingAttraction.java
@@ -1,5 +1,7 @@
 package com.yapp.backend.service.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yapp.backend.service.model.DistanceInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,4 +17,9 @@ public class ScrapingAttraction {
     private String type;
     private Double latitude;
     private Double longitude;
+    @JsonProperty("ByFoot")
+    private DistanceInfo byFoot;
+    @JsonProperty("ByCar")
+    private DistanceInfo byCar;
+
 }

--- a/src/main/java/com/yapp/backend/service/dto/ScrapingTransportation.java
+++ b/src/main/java/com/yapp/backend/service/dto/ScrapingTransportation.java
@@ -1,5 +1,7 @@
 package com.yapp.backend.service.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yapp.backend.service.model.DistanceInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,4 +17,10 @@ public class ScrapingTransportation {
     private String type;
     private Double latitude;
     private Double longitude;
+
+    @JsonProperty("ByFoot")
+    private DistanceInfo byFoot;
+    @JsonProperty("ByCar")
+    private DistanceInfo byCar;
+
 }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 데이터 스크래핑 객체가 DB엔티티로 매핑되는 과정에서 거리정보 추가
<img width="350" height="400" alt="image" src="https://github.com/user-attachments/assets/8bdeb471-bade-46b4-bd3d-8af8f3cd1659" />
<img width="350" height="400" alt="image" src="https://github.com/user-attachments/assets/bdce5d16-a134-40f3-ace0-f6c7bde2c125" />


### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [ ] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 관광지와 이동수단에 도보(ByFoot)·차량(ByCar) 기준 거리 및 소요시간 정보가 추가되었습니다.
  * 목록 및 상세 화면에서 도보/차량별 거리와 소요시간을 확인할 수 있습니다.
  * 외부 데이터의 ByFoot/ByCar 필드가 자동 반영되어 이동 정보가 더 정확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->