### PR TITLE
[Y26W2-332] 비교표 생성시 표 이름 자동 생성

### DIFF
--- a/src/main/java/com/yapp/backend/common/util/ComparisonTableNameGeneratorUtil.java
+++ b/src/main/java/com/yapp/backend/common/util/ComparisonTableNameGeneratorUtil.java
@@ -1,0 +1,19 @@
+package com.yapp.backend.common.util;
+
+/**
+ * 비교표 이름 자동 생성을 위한 유틸리티 클래스
+ */
+public class ComparisonTableNameGeneratorUtil {
+
+    /**
+     * 시퀀스 번호를 기반으로 비교표 이름을 생성합니다.
+     * 형식: "표 {순번}"
+     * 
+     * @param sequenceNumber 시퀀스 번호
+     * @return 자동 생성된 비교표 이름
+     */
+    public static String generateTableName(int sequenceNumber) {
+        return String.format("표 %d", sequenceNumber);
+    }
+
+}

--- a/src/main/java/com/yapp/backend/controller/dto/request/CreateComparisonTableRequest.java
+++ b/src/main/java/com/yapp/backend/controller/dto/request/CreateComparisonTableRequest.java
@@ -1,6 +1,5 @@
 package com.yapp.backend.controller.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -11,7 +10,7 @@ public class CreateComparisonTableRequest {
     @NotNull(message = "여행 보드 ID는 필수 입력값입니다.")
     private Long tripBoardId;
 
-    @NotBlank
+    // tableName이 null이거나 빈 문자열이면 자동 생성됩니다
     private String tableName;
 
     @NotEmpty(message = "숙소 정렬 순서대로 ID를 입력해주세요. 1개 이상 필수 입력입니다.")

--- a/src/main/java/com/yapp/backend/repository/JpaTripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/JpaTripBoardRepository.java
@@ -2,10 +2,12 @@ package com.yapp.backend.repository;
 
 import com.yapp.backend.repository.entity.TripBoardEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 
 @Repository
@@ -17,4 +19,11 @@ public interface JpaTripBoardRepository extends JpaRepository<TripBoardEntity, L
     @Query("SELECT tb FROM TripBoardEntity tb WHERE tb.id = :tripBoardId AND tb.createdBy.id = :createdById")
     Optional<TripBoardEntity> findByIdAndCreatedById(@Param("tripBoardId") Long tripBoardId,
             @Param("createdById") Long createdById);
+
+    /**
+     * 특정 여행보드의 다음 비교표 번호를 조회하고 증가시킵니다 (락 사용)
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT tb FROM TripBoardEntity tb WHERE tb.id = :tripBoardId")
+    Optional<TripBoardEntity> getAndIncrementSequenceNumber(@Param("tripBoardId") Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/TripBoardRepository.java
+++ b/src/main/java/com/yapp/backend/repository/TripBoardRepository.java
@@ -66,4 +66,11 @@ public interface TripBoardRepository {
      * 존재하지 않는 경우 Optional.empty() 반환
      */
     Optional<TripBoard> findById(Long id);
+
+    /**
+     * 특정 여행보드의 다음 비교표 번호를 가져옵니다.
+     * @param tripBoardId 여행보드 ID
+     * @return 다음 비교표 번호
+     */
+    int getNextComparisonTableNumber(Long tripBoardId);
 }

--- a/src/main/java/com/yapp/backend/repository/entity/TripBoardEntity.java
+++ b/src/main/java/com/yapp/backend/repository/entity/TripBoardEntity.java
@@ -82,4 +82,12 @@ public class TripBoardEntity {
         this.endDate = endDate;
         this.updatedBy = updatedBy;
     }
+
+    /**
+     * 다음 비교표 번호를 가져오고 증가시킵니다.
+     * @return 다음 비교표 번호
+     */
+    public int getAndIncrementNumber() {
+        return nextComparisonTableNumber++;
+    }
 }

--- a/src/main/java/com/yapp/backend/repository/entity/TripBoardEntity.java
+++ b/src/main/java/com/yapp/backend/repository/entity/TripBoardEntity.java
@@ -12,7 +12,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -60,6 +59,10 @@ public class TripBoardEntity {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @Column(name = "next_comparison_table_number", nullable = false)
+    @Builder.Default
+    private Integer nextComparisonTableNumber = 1;
 
     @OneToMany(mappedBy = "tripBoardEntity"
     // cascade = CascadeType.ALL,

--- a/src/main/java/com/yapp/backend/repository/impl/TripBoardRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/TripBoardRepositoryImpl.java
@@ -163,4 +163,16 @@ public class TripBoardRepositoryImpl implements TripBoardRepository {
                 .map(tripBoardMapper::entityToDomain);
     }
 
+    @Override
+    @Transactional
+    public int getNextComparisonTableNumber(Long tripBoardId) {
+        TripBoardEntity tripBoard = jpaTripBoardRepository.getAndIncrementSequenceNumber(tripBoardId)
+                .orElseThrow(TripBoardNotFoundException::new);
+        
+        int nextNumber = tripBoard.getAndIncrementNumber();
+        jpaTripBoardRepository.save(tripBoard);
+        
+        return nextNumber;
+    }
+
 }

--- a/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
@@ -3,6 +3,7 @@ package com.yapp.backend.service.impl;
 import com.yapp.backend.common.exception.ComparisonTableDeleteException;
 import com.yapp.backend.common.exception.ErrorCode;
 import com.yapp.backend.common.exception.UserAuthorizationException;
+import com.yapp.backend.common.util.ComparisonTableNameGeneratorUtil;
 import com.yapp.backend.controller.dto.request.AddAccommodationRequest;
 import com.yapp.backend.controller.dto.request.CreateComparisonTableRequest;
 import com.yapp.backend.controller.dto.request.UpdateAccommodationRequest;
@@ -26,7 +27,6 @@ import com.yapp.backend.service.model.ComparisonTable;
 import com.yapp.backend.service.model.TripBoard;
 import com.yapp.backend.service.model.enums.ComparisonFactor;
 
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -194,10 +194,19 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
             );
         }
 
+        // 비교표 이름 자동 생성 (tableName이 null이거나 빈 문자열인 경우)
+        String tableName = request.getTableName();
+        if (tableName == null || tableName.trim().isEmpty()) {
+            int nextNumber = tripBoardRepository.getNextComparisonTableNumber(tripBoard.getId());
+            tableName = ComparisonTableNameGeneratorUtil.generateTableName(nextNumber);
+            log.debug("비교표 이름 자동 생성 - tripBoardId: {}, destination: {}, nextNumber: {}, generatedName: {}", 
+                    tripBoard.getId(), tripBoard.getDestination(), nextNumber, tableName);
+        }
+
         // 저장하고 생성된 테이블 ID 반환
         Long tableId = comparisonTableRepository.save(
                 ComparisonTable.from(
-                        request.getTableName(),
+                        tableName,
                         userRepository.findByIdOrThrow(userId),
                         tripBoard,
                         accommodationList,

--- a/src/main/resources/flyway/migration/V14__add_next_comparison_table_number.sql
+++ b/src/main/resources/flyway/migration/V14__add_next_comparison_table_number.sql
@@ -1,0 +1,3 @@
+-- 여행보드 테이블에 다음 비교표 번호 필드 추가
+ALTER TABLE trip_board 
+ADD COLUMN next_comparison_table_number INTEGER NOT NULL DEFAULT 1;


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 여행보드 엔티티에 `next_comparison_table_number` 필드가 추가되었습니다.
- 여행보드 마다 비교표 이름이 빈 문자열이나 Null 일 경우 "표 1", "표 2" 와 같이 자동 생성해서 저장합니다.

### PR 체크리스트
- [ ] 정상적으로 실행이 되나요?
- [ ] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [ ] 컨벤션 규칙을 지켰나요?
- [ ] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->