### PR TITLE
[Y26W2-382] 메모 수정 후 바로 조회 가능하게 수정

### DIFF
--- a/src/main/java/com/yapp/backend/repository/impl/AccommodationRepositoryImpl.java
+++ b/src/main/java/com/yapp/backend/repository/impl/AccommodationRepositoryImpl.java
@@ -5,8 +5,6 @@ import com.yapp.backend.common.exception.ErrorCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.yapp.backend.repository.AccommodationRepository;
@@ -15,7 +13,6 @@ import com.yapp.backend.repository.entity.AccommodationEntity;
 import com.yapp.backend.repository.enums.SortType;
 import com.yapp.backend.repository.mapper.AccommodationMapper;
 import com.yapp.backend.service.model.Accommodation;
-import jakarta.persistence.EntityManager;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,7 +24,6 @@ import java.util.stream.Collectors;
 public class AccommodationRepositoryImpl implements AccommodationRepository {
     private final JpaAccommodationRepository jpaAccommodationRepository;
     private final AccommodationMapper accommodationMapper;
-    private final EntityManager entityManager;
 
     /**
      * 여행보드 ID로 숙소 목록을 페이징하여 조회하는 쿼리

--- a/src/main/java/com/yapp/backend/service/impl/AccommodationServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/AccommodationServiceImpl.java
@@ -201,7 +201,7 @@ public class AccommodationServiceImpl implements AccommodationService {
 			// 숙소 존재 여부 확인
 			Accommodation accommodation = accommodationRepository.findByIdOrThrow(accommodationId);
 
-			// 업데이트된 도메인 객체를 저장
+			// 메모 업데이트
 			accommodationRepository.updateMemoById(accommodationId, memo);
 
 			log.info("숙소 메모 업데이트 완료 - 숙소 ID: {}", accommodationId);


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 도메인 객체에서 메모를 수정하여 해당 도메인으로 업데이트
- 수정날짜는 @UpdateTimestamp 로 업데이트
 
### PR 체크리스트
- [ ] 정상적으로 실행이 되나요?
- [ ] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [ ] 컨벤션 규칙을 지켰나요?
- [ ] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과
<img width="467" height="190" alt="image" src="https://github.com/user-attachments/assets/6ab4955e-17c0-403b-9244-cc2f53d1721d" />
<img width="578" height="59" alt="image" src="https://github.com/user-attachments/assets/e50e88e0-b2c8-4e32-930f-e9a0b61f6e4c" />

-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 해당 PR에는 사용자에게 노출되는 신규 기능이 없습니다.
- 버그 수정
  - 숙소 메모 업데이트 시 불필요하게 다른 정보가 함께 변경되던 동작을 바로잡아, 메모만 반영되도록 조정했습니다. 기록 표기의 일관성이 향상됩니다.
- 유지보수
  - 메모 업데이트 흐름의 시작/완료 로그를 보강해 운영 모니터링을 개선했습니다.
  - 데이터 갱신 후 컨텍스트 정리를 자동화해 안정성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->