### PR TITLE
[Y26W2-386] 비교표 조회 시 LazyInitializationException 에러 해결

### DIFF
--- a/src/main/java/com/yapp/backend/controller/ComparisonTableController.java
+++ b/src/main/java/com/yapp/backend/controller/ComparisonTableController.java
@@ -1,8 +1,5 @@
 package com.yapp.backend.controller;
 
-import static com.yapp.backend.common.exception.ErrorCode.*;
-
-import com.yapp.backend.common.exception.ShareCodeException;
 import com.yapp.backend.common.annotation.PublicApi;
 import com.yapp.backend.common.response.ResponseType;
 import com.yapp.backend.common.response.StandardResponse;
@@ -54,8 +51,7 @@ import com.yapp.backend.controller.mapper.ComparisonTableResponseMapper;
 public class ComparisonTableController implements ComparisonDocs {
 
     private final ComparisonTableService comparisonTableService;
-    private final ComparisonTableResponseMapper comparisonTableResponseMapper;
-    private final UserService userService;
+
 
     @Override
     @PublicApi(description = "비교 기준 항목 목록 조회 - 인증 불필요")
@@ -95,11 +91,9 @@ public class ComparisonTableController implements ComparisonDocs {
             @PathVariable("tableId") Long tableId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        ComparisonTable comparisonTable = comparisonTableService.getComparisonTableWithAuthorization(tableId, userDetails.getUserId());
-        User creator = userService.getUserById(comparisonTable.getCreatedById());
-        ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable, creator.getNickname());
+        ComparisonTableResponse comparisonTableResponse = comparisonTableService.getComparisonTableWithAuthorization(tableId, userDetails.getUserId());
 
-        return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
+        return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, comparisonTableResponse));
     }
 
     /**
@@ -112,26 +106,11 @@ public class ComparisonTableController implements ComparisonDocs {
             @PathVariable("tableId") Long tableId,
             @RequestParam("shareCode") String shareCode) {
 
-        ComparisonTable comparisonTable = comparisonTableService.getComparisonTable(tableId);
+        ComparisonTableResponse comparisonTableResponse = comparisonTableService.getComparisonTable(tableId, shareCode);
 
-        // shareCode 검증
-        validateShareCodeAccess(tableId, shareCode, comparisonTable);
-
-        User creator = userService.getUserById(comparisonTable.getCreatedById());
-        ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable, creator.getNickname());
-        return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
+        return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, comparisonTableResponse));
     }
 
-    /**
-     * shareCode를 통한 접근 권한 검증
-     */
-    private void validateShareCodeAccess(Long tableId, String shareCode, ComparisonTable comparisonTable) {
-        if (!shareCode.equals(comparisonTable.getShareCode())) {
-            log.warn("유효하지 않은 shareCode로 비교표 조회 시도 - tableId: {}, shareCode: {}", tableId, shareCode);
-            throw new ShareCodeException(INVALID_SHARE_CODE);
-        }
-        log.info("shareCode를 통한 비교표 조회 성공 - tableId: {}, shareCode: {}", tableId, shareCode);
-    }
 
     @Override
     @PutMapping("/{tableId}")
@@ -153,11 +132,9 @@ public class ComparisonTableController implements ComparisonDocs {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();
 
-        ComparisonTable comparisonTable = comparisonTableService.addAccommodationToComparisonTableWithAuthorization(tableId, request, userId);
-        User creator = userService.getUserById(comparisonTable.getCreatedById());
-        ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable, creator.getNickname());
+        ComparisonTableResponse comparisonTableResponse = comparisonTableService.addAccommodationToComparisonTableWithAuthorization(tableId, request, userId);
 
-        return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, response));
+        return ResponseEntity.ok(new StandardResponse<>(ResponseType.SUCCESS, comparisonTableResponse));
     }
 
     @Override

--- a/src/main/java/com/yapp/backend/service/ComparisonTableService.java
+++ b/src/main/java/com/yapp/backend/service/ComparisonTableService.java
@@ -4,6 +4,7 @@ import com.yapp.backend.controller.dto.request.AddAccommodationRequest;
 import com.yapp.backend.controller.dto.request.CreateComparisonTableRequest;
 import com.yapp.backend.controller.dto.request.UpdateComparisonTableRequest;
 import com.yapp.backend.controller.dto.response.ComparisonTablePageResponse;
+import com.yapp.backend.controller.dto.response.ComparisonTableResponse;
 import org.springframework.data.domain.Pageable;
 import com.yapp.backend.service.model.ComparisonTable;
 
@@ -22,7 +23,7 @@ public interface ComparisonTableService {
      * @param tableId 비교 테이블 ID
      * @return 비교 테이블 정보
      */
-    ComparisonTable getComparisonTable(Long tableId);
+    ComparisonTableResponse getComparisonTable(Long tableId, String shareCode);
 
     /**
      * 사용자 권한을 검증하고 비교 테이블의 상세 정보를 조회합니다.
@@ -30,7 +31,7 @@ public interface ComparisonTableService {
      * @param userId 사용자 ID
      * @return 비교 테이블 정보
      */
-    ComparisonTable getComparisonTableWithAuthorization(Long tableId, Long userId);
+    ComparisonTableResponse getComparisonTableWithAuthorization(Long tableId, Long userId);
 
     /**
      * 사용자 권한을 검증하고 비교테이블의 상세 정보를 수정합니다.
@@ -48,7 +49,7 @@ public interface ComparisonTableService {
      * @param userId 사용자 ID
      * @return 업데이트된 비교 테이블
      */
-    ComparisonTable addAccommodationToComparisonTableWithAuthorization(Long tableId, AddAccommodationRequest request, Long userId);
+    ComparisonTableResponse addAccommodationToComparisonTableWithAuthorization(Long tableId, AddAccommodationRequest request, Long userId);
 
     /**
      * 사용자 권한을 검증하고 특정 비교 테이블을 삭제합니다.

--- a/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
@@ -87,7 +87,7 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
         // shareCode 검증
         validateShareCodeAccess(tableId, shareCode, comparisonTable);
 
-        User creator = userService.getUserById(comparisonTable.getCreatedById());
+        User creator = userRepository.findByIdOrThrow(comparisonTable.getCreatedById());
         ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable, creator.getNickname());
 
         log.debug("비교 테이블 조회 완료 - tableId: {}", tableId);
@@ -103,7 +103,7 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
 
         // 권한 검증 (엔티티 객체 전달)
         authorizationService.validateReadPermission(comparisonTable, userId);
-        User creator = userRepository.findByIdOrThrow(userId);
+        User creator = userRepository.findByIdOrThrow(comparisonTable.getCreatedById());
         ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable, creator.getNickname());
 
 

--- a/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
@@ -57,12 +57,10 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
     private final UserRepository userRepository;
     private final AccommodationRepository accommodationRepository;
     private final AccommodationService accommodationService;
-    private final ComparisonTableResponseMapper responseMapper;
+    private final ComparisonTableResponseMapper comparisonTableResponseMapper;
     private final UserComparisonTableAuthorizationService authorizationService;
     private final UserTripBoardAuthorizationService tripBoardAuthorizationService;
     private final UserAccommodationAuthorizationService accommodationAuthorizationService;
-
-    private final ComparisonTableResponseMapper comparisonTableResponseMapper;
     private final UserService userService;
 
     // ==================== Public Methods (Controller에서 호출) ====================
@@ -105,7 +103,7 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
 
         // 권한 검증 (엔티티 객체 전달)
         authorizationService.validateReadPermission(comparisonTable, userId);
-        User creator = userService.getUserById(comparisonTable.getCreatedById());
+        User creator = userRepository.findByIdOrThrow(userId);
         ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable, creator.getNickname());
 
 
@@ -367,7 +365,7 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
         }
         
         // 매퍼를 사용하여 Response DTO로 변환
-        List<ComparisonTableSummaryResponse> responseList = responseMapper.toResponseList(comparisonTables);
+        List<ComparisonTableSummaryResponse> responseList = comparisonTableResponseMapper.toResponseList(comparisonTables);
         
         // 페이지 응답 객체로 감싸서 반환
         ComparisonTablePageResponse response = ComparisonTablePageResponse.of(responseList, hasNext);
@@ -396,9 +394,9 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
      */
     private void validateShareCodeAccess(Long tableId, String shareCode, ComparisonTable comparisonTable) {
         if (!shareCode.equals(comparisonTable.getShareCode())) {
-            log.warn("유효하지 않은 shareCode로 비교표 조회 시도 - tableId: {}, shareCode: {}", tableId, shareCode);
+            log.warn("유효하지 않은 shareCode로 비교표 조회 시도 - tableId: {}", tableId);
             throw new ShareCodeException(INVALID_SHARE_CODE);
         }
-        log.info("shareCode를 통한 비교표 조회 성공 - tableId: {}, shareCode: {}", tableId, shareCode);
+        log.info("shareCode를 통한 비교표 조회 성공 - tableId: {}", tableId);
     }
 }

--- a/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
+++ b/src/main/java/com/yapp/backend/service/impl/ComparisonTableServiceImpl.java
@@ -1,7 +1,10 @@
 package com.yapp.backend.service.impl;
 
+import static com.yapp.backend.common.exception.ErrorCode.INVALID_SHARE_CODE;
+
 import com.yapp.backend.common.exception.ComparisonTableDeleteException;
 import com.yapp.backend.common.exception.ErrorCode;
+import com.yapp.backend.common.exception.ShareCodeException;
 import com.yapp.backend.common.exception.UserAuthorizationException;
 import com.yapp.backend.common.util.ComparisonTableNameGeneratorUtil;
 import com.yapp.backend.controller.dto.request.AddAccommodationRequest;
@@ -9,9 +12,12 @@ import com.yapp.backend.controller.dto.request.CreateComparisonTableRequest;
 import com.yapp.backend.controller.dto.request.UpdateAccommodationRequest;
 import com.yapp.backend.controller.dto.request.UpdateComparisonTableRequest;
 import com.yapp.backend.controller.dto.response.ComparisonTablePageResponse;
+import com.yapp.backend.controller.dto.response.ComparisonTableResponse;
 import com.yapp.backend.controller.dto.response.ComparisonTableSummaryResponse;
 import com.yapp.backend.controller.mapper.ComparisonTableResponseMapper;
+import com.yapp.backend.service.UserService;
 import com.yapp.backend.service.authorization.UserAccommodationAuthorizationService;
+import com.yapp.backend.service.model.User;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import com.yapp.backend.repository.AccommodationRepository;
@@ -42,6 +48,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ComparisonTableServiceImpl implements ComparisonTableService {
 
@@ -54,6 +61,9 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
     private final UserComparisonTableAuthorizationService authorizationService;
     private final UserTripBoardAuthorizationService tripBoardAuthorizationService;
     private final UserAccommodationAuthorizationService accommodationAuthorizationService;
+
+    private final ComparisonTableResponseMapper comparisonTableResponseMapper;
+    private final UserService userService;
 
     // ==================== Public Methods (Controller에서 호출) ====================
 
@@ -70,17 +80,24 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
     }
 
     @Override
-    public ComparisonTable getComparisonTable(Long tableId) {
+    public ComparisonTableResponse getComparisonTable(Long tableId, String shareCode) {
         log.debug("비교 테이블 조회 시작 - tableId: {}", tableId);
         
         // 리소스를 한 번만 조회
         ComparisonTable comparisonTable = comparisonTableRepository.findByIdOrThrow(tableId);
+
+        // shareCode 검증
+        validateShareCodeAccess(tableId, shareCode, comparisonTable);
+
+        User creator = userService.getUserById(comparisonTable.getCreatedById());
+        ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable, creator.getNickname());
+
         log.debug("비교 테이블 조회 완료 - tableId: {}", tableId);
-        return comparisonTable;
+        return response;
     }
 
     @Override
-    public ComparisonTable getComparisonTableWithAuthorization(Long tableId, Long userId) {
+    public ComparisonTableResponse getComparisonTableWithAuthorization(Long tableId, Long userId) {
         log.debug("비교 테이블 조회 시작 (권한 검증 포함) - tableId: {}, userId: {}", tableId, userId);
 
         // 리소스를 한 번만 조회
@@ -88,9 +105,12 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
 
         // 권한 검증 (엔티티 객체 전달)
         authorizationService.validateReadPermission(comparisonTable, userId);
+        User creator = userService.getUserById(comparisonTable.getCreatedById());
+        ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable, creator.getNickname());
+
 
         log.debug("비교 테이블 조회 완료 (권한 검증 포함) - tableId: {}, userId: {}", tableId, userId);
-        return comparisonTable;
+        return response;
     }
 
     @Override
@@ -110,7 +130,7 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
 
     @Override
     @Transactional
-    public ComparisonTable addAccommodationToComparisonTableWithAuthorization(Long tableId, AddAccommodationRequest request, Long userId) {
+    public ComparisonTableResponse addAccommodationToComparisonTableWithAuthorization(Long tableId, AddAccommodationRequest request, Long userId) {
         log.debug("비교 테이블에 숙소 추가 시작 (권한 검증 포함) - tableId: {}, userId: {}", tableId, userId);
         
         // 리소스를 한 번만 조회
@@ -120,7 +140,10 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
         authorizationService.validateUpdatePermission(existingTable, userId);
         
         // 순수 비즈니스 로직 실행
-        return addAccommodationToComparisonTableInternal(tableId, request, userId);
+        ComparisonTable comparisonTable = addAccommodationToComparisonTableInternal(tableId, request, userId);
+        User creator = userService.getUserById(comparisonTable.getCreatedById());
+        ComparisonTableResponse response = comparisonTableResponseMapper.toResponse(comparisonTable, creator.getNickname());
+        return response;
     }
 
     @Override
@@ -365,5 +388,17 @@ public class ComparisonTableServiceImpl implements ComparisonTableService {
                 accommodationService.updateAccommodation(accommodationRequest);
             }
         }
+    }
+
+
+    /**
+     * shareCode를 통한 접근 권한 검증
+     */
+    private void validateShareCodeAccess(Long tableId, String shareCode, ComparisonTable comparisonTable) {
+        if (!shareCode.equals(comparisonTable.getShareCode())) {
+            log.warn("유효하지 않은 shareCode로 비교표 조회 시도 - tableId: {}, shareCode: {}", tableId, shareCode);
+            throw new ShareCodeException(INVALID_SHARE_CODE);
+        }
+        log.info("shareCode를 통한 비교표 조회 성공 - tableId: {}, shareCode: {}", tableId, shareCode);
     }
 }

--- a/src/main/resources/config/postgresql/db-dev.yml
+++ b/src/main/resources/config/postgresql/db-dev.yml
@@ -6,6 +6,7 @@ spring:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://${DB_PRIVATE_IP}:5432/${TEST_DB_NAME}
   jpa:
+    open-in-view: false
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/config/postgresql/db-local.yml
+++ b/src/main/resources/config/postgresql/db-local.yml
@@ -6,6 +6,7 @@ spring:
     password: ${LOCAL_DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:
+    open-in-view: false
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항

**비교표 조회 시 `LazyInitializationException` 에러 해결**
<img width="692" height="203" alt="image" src="https://github.com/user-attachments/assets/83da76ce-2301-4545-8798-0624821b2e0e" />


**원인**
DB 커넥션을 줄이기 위해 컨트롤러에서는 영속성 컨텍스트 끝나도록 설정해둠(open-in-view: false 설정)
하지만 비교표 조회시 컨트롤러 단에서 영속성 접근을 시도하기 때문에 `LazeInitialization`예외 발생
- 비교표 : 숙소 = `@OneToMany` 연관관계
- Lazy 로딩으로 숙소 프록시 객체 들고 있음
- 컨트롤러에서 DTO 변환을 시도하면서 프록시 객체에서 DB조회 시도
- 하지만 이미 영속성 컨텍스트이 닫혀있음 => 예외 발생

**해결**
트랜잭션 계층 경계를 명확히 하기 위해 `open-in-view : false` 설정은 그대로
서비스 계층(트랜잭션 내)에서 DTO 매핑한 뒤 반환

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과
<img width="386" height="310" alt="image" src="https://github.com/user-attachments/assets/0f2e27f7-59f2-4c19-941d-8c9f9a087e76" />


-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 공유코드 기반 접근 검증을 추가해 비교표 조회 보안을 강화했습니다.

- Improvements
  - 비교표 조회·숙소 추가 시 클라이언트에 반환되는 응답을 DTO로 통일해 일관성과 가독성을 향상했습니다.
  - 응답 구성 흐름을 서비스 중심으로 단순화해 안정성과 신뢰성을 개선했습니다.

- Refactor
  - 컨트롤러·서비스 간 책임을 재정리해 유지보수성을 높였습니다.

- Chores
  - 개발/로컬 JPA 설정에서 open-in-view를 비활성화해 데이터 처리 안정성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->