### PR TITLE
[Y26W2-407] 비교표 생성 가능한 호텔 개수를 10개로 제한

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ out/
 
 ### kiro ###
 .kiro
+
+### cluade ###
+CLAUDE.md
+
+### copilot ###
+.github/git-commit-instructions.md

--- a/src/main/java/com/yapp/backend/controller/dto/request/CreateComparisonTableRequest.java
+++ b/src/main/java/com/yapp/backend/controller/dto/request/CreateComparisonTableRequest.java
@@ -2,6 +2,7 @@ package com.yapp.backend.controller.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Getter;
 
@@ -14,6 +15,7 @@ public class CreateComparisonTableRequest {
     private String tableName;
 
     @NotEmpty(message = "숙소 정렬 순서대로 ID를 입력해주세요. 1개 이상 필수 입력입니다.")
+    @Size(min = 1, max = 10, message = "비교표에는 최소 1개, 최대 10개의 숙소를 추가할 수 있습니다.")
     private List<Long> accommodationIdList;
 
     // factorList가 비어있거나 null이면 모든 비교 요소가 디폴트 순서로 자동 설정됩니다


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
비교표 생성 가능한 호텔 개수를 최대 10개로 제한

### PR 체크리스트
- [X] 정상적으로 실행이 되나요?
- [X] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [X] 컨벤션 규칙을 지켰나요?
- [X] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과
TO-BE
<img width="1393" height="197" alt="image" src="https://github.com/user-attachments/assets/63bdea37-f380-4194-96b4-ee0b8995151e" />


-----
<!-- PR_BODY_START -->
<!-- PR_BODY_END -->